### PR TITLE
Possibilité tester compilation PDF hors de master

### DIFF
--- a/.github/workflows/bookdown_pdf_test.yaml
+++ b/.github/workflows/bookdown_pdf_test.yaml
@@ -1,10 +1,6 @@
-on:
-  push:
-    branches:
-      - main
-      - master
+on: [pull_request]
 
-name: documentation version PDF
+name: test compilation PDF
 
 jobs:
   build:


### PR DESCRIPTION
Comme il est souvent nécessaire de tester la compilation PDF avant de merger, cette PR propose de déclencher une action à chaque PR