### PR TITLE
Remaniement introduction

### DIFF
--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -172,10 +172,5 @@ Le _package_ `doremifasolData` n'est pas disponible sur le répertoire central d
     remotes::install_github("InseeFrLab/doremifasolData", ref = "main")
     ```
 
-## Comment contribuer au projet `utilitR`
-
-**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Le dépôt de la documentation est situé à [cette adresse](https://github.com/InseeFrLab/utilitR). Les objectifs et l'approche collaborative du projet `utilitR` sont détaillés dans le document `Manifeste.md`.
-
-**Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).
 
 

--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -4,10 +4,10 @@
 
 **Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. Elle veille en outre à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS). En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
 
-Cette documentation a pour ambition de répondre à deux questions générales :
+<!-- Cette documentation a pour ambition de répondre à deux questions générales : -->
 
-* Comment travailler avec `R` à l'Insee ?
-* Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
+<!-- * Comment travailler avec `R` à l'Insee ? -->
+<!-- * Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ? -->
 
 Trois points importants sont à noter :
 

--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -1,5 +1,21 @@
 # Comment utiliser la documentation `utilitR`
 
+## Contenu de la documentation
+
+**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. Elle veille en outre à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS). En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
+
+Cette documentation a pour ambition de répondre à deux questions générales :
+
+* Comment travailler avec `R` à l'Insee ?
+* Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
+
+Trois points importants sont à noter :
+
+* **Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee**. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
+* Cette documentation ne prétend pas être exhaustive ou sans erreurs. **Elle doit être vue comme une mise en commun des connaissances sur `R` que les agents de la statistique publique ont accumulées dans le cadre de leurs activités.**
+* **Cette documentation recommande d'utiliser `R` avec  RStudio**, qui apparaît comme la solution la plus simple et la plus complète pour un usage courant de `R`, et qui est par ailleurs le choix effectué par l'Insee.
+
+
 ## Structure de la documentation
 
 **La documentation `utilitR` est composée de fiches regroupées en deux grandes parties** : 

--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -22,17 +22,11 @@ texte_recommandation <- "Ce paragraphe présente succinctement les outils et les
 texte_conseil        <- "Ce paragraphe détaille les bonnes pratiques à adopter."
 texte_remarque       <- "Ce paragraphe donne des informations supplémentaires ou formule une mise en garde."
 
-if (knitr::is_latex_output()) {
-  symb  <- 
-    c("{\\Huge \\color{Red} \\faHandPointRight}", 
-      "{\\Huge \\color{Cerulean} \\faLightbulb}", 
-      "{\\Huge \\color{Yellow} \\faInfoCircle}")
-} else if (knitr::is_html_output()) {
-  symb  <- 
-        c(fa("hand-point-right", fill = "rgba(220, 53, 69, 1)", height = 40),
-        fa("lightbulb", fill = "rgba(255, 193, 7, 1)", height = 40),
-        fa("info-circle", fill = "rgba(0, 123, 255, 1)", height = 40))
-}
+
+symb  <- 
+  c(fa("hand-point-right", fill = "rgba(220, 53, 69, 1)", height = 40),
+    fa("lightbulb", fill = "rgba(255, 193, 7, 1)", height = 40),
+    fa("info-circle", fill = "rgba(0, 123, 255, 1)", height = 40))
 
 dt <- 
   as.data.frame(list(
@@ -46,25 +40,15 @@ dt <-
   )
   )
 
-if (knitr::is_latex_output()) {
-  output <- 
-    dt %>% 
-    kable(escape = FALSE, position = "center", align="ccl") %>%
-  kable_classic_2(full_width = F)
-  row_spec(output, 0, bold=TRUE, align = "c") %>%
-    column_spec(1, width = "3cm", bold = TRUE) %>%
-    column_spec(2, width = "2cm") %>% 
-    column_spec(3, width = "10cm")
-} else if (knitr::is_html_output()) {
-  output <- 
-    dt %>% 
-    kable(escape = F, position = "center", full_width = F, align="ccl") %>%
+
+output <- 
+  dt %>% 
+  kable(escape = F, position = "center", full_width = F, align="ccl") %>%
   kable_classic_2(full_width = F, html_font = '"Arial", arial, helvetica, sans-serif')
-  column_spec(output, 1, width = "3cm", bold = TRUE) %>%
-    column_spec(2, width = "2cm") %>% 
-    column_spec(3, width = "10cm") %>% 
-    row_spec(0,bold=TRUE, align = "c")
-}
+column_spec(output, 1, width = "3cm", bold = TRUE) %>%
+  column_spec(2, width = "2cm") %>% 
+  column_spec(3, width = "10cm") %>% 
+  row_spec(0,bold=TRUE, align = "c")
 ```
 
 ## Des exemples reproductibles
@@ -102,17 +86,6 @@ Voici la liste des tables disponibles dans `doremifasolData` :
 ```{r "contenu_doremifasolData", echo = FALSE, results = "asis"}
 tables <- data(package = "doremifasolData")$result
 
-if (knitr::is_latex_output()) {
-output <- 
-  knitr::kable(
-  as.data.frame(list("Table" = tables[, "Item"], "Description" = tables[, "Title"])),
-  format = "latex",
-  escape = TRUE, position = "center", align="cl") %>%
-  kable_classic_2(full_width = F)
-  column_spec(output, 1, width = "4cm") %>%
-    column_spec(2, width = "13cm") %>% 
-    row_spec(0, bold=TRUE, align = "c")
-} else if (knitr::is_html_output()) {
 output <- 
   knitr::kable(
   as.data.frame(list("Table" = tables[, "Item"], "Description" = tables[, "Title"])),
@@ -122,7 +95,6 @@ output <-
 column_spec(output, 1, width = "4cm") %>%
     column_spec(2, width = "13cm") %>% 
     row_spec(0, bold=TRUE, align = "c")
-}
 
 ```
 

--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -1,38 +1,13 @@
-# Introduction
+# Comment utiliser la documentation `utilitR`
 
-## Présentation du projet `utilitR`
-
-### Quel est l'objectif du projet `utilitR` ?
-
-**Le projet `utilitR` vise à produire une documentation collaborative et _open source_ sur `R`, destinée en premier lieu aux agents de l'Insee.** Ce projet est parti du constat qu'il est difficile d'apprendre à utiliser `R` pour de multiples raisons : multiplicité de _packages_ faisant plus ou moins la même chose, abondance et éclatement de la documentation (souvent en anglais), difficultés supplémentaires pour effectuer des choix éclairés et adaptés à l'environnement informatique de travail...
-
-Les contributeurs du projet `utilitR` se sont fixés pour objectif de **rassembler  dans un seul document tous les éléments utiles pour l'usage de `R` à l'Insee, en cherchant à couvrir la plupart des cas d'usage courants.** Cette documentation a donc été élaborée en tenant compte du contexte de travail propre à l'institut. Cette documentation peut évidemment contenir des éléments pertinents pour un usage de `R` en dehors de l'Insee, mais ce n'est pas sa finalité première.
-
-### Que contient la documentation `utilitR` ?
-
-**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
-
-Deux points importants sont à noter :
-
-* **Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee**. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
-* **Cette documentation recommande d'utiliser `R` avec  RStudio**, qui apparaît comme la solution la plus simple et la plus complète pour un usage courant de `R`, et qui est par ailleurs le choix effectué par l'Insee.
-
-### Quelle est la spécificité du projet `utilitR` ?
-
-**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Tout agent qui le souhaite peut modifier la documentation ou la compléter en fonction de ses connaissances et de ses expériences (voir [Comment fonctionne le projet `utilitR` ?]).
-
-Cette documentation ne prétend pas être exhaustive ou sans erreurs. **Elle doit être vue comme une mise en commun des connaissances que les agents détiennent sur l'usage de `R`.**
-
-## Comment utiliser la documentation `utilitR`
-
-### Structure de la documentation
+## Structure de la documentation
 
 **La documentation `utilitR` est composée de fiches regroupées en deux grandes parties** : 
 
 - La première partie explique comment utiliser `R` et  RStudio et les outils associés (`git`, Gitlab) dans les environnements informatiques proposés à l'Insee (AUSv3 et SSP Cloud). 
 - La seconde partie est constituée de fiches thématiques expliquant comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, réalisation de graphiques, rédaction de documents...).
 
-### Contenu des fiches
+## Contenu des fiches
 
 Chaque fiche porte sur une tâche précise, décrite dans le titre et éventuellement dans les premières lignes. Elle indique quels sont les _packages_ adaptés pour réaliser la tâche en question, et en présente en détail les principales fonctions. Les fiches n'ont toutefois pas la prétention d'être exhaustives ; c'est pourquoi des références figurent à la fin de chaque fiche de façon à orienter le lecteur vers des ressources plus détaillées.
 
@@ -92,7 +67,7 @@ if (knitr::is_latex_output()) {
 }
 ```
 
-### Des exemples reproductibles
+## Des exemples reproductibles
 
 Même si certains lecteurs ont uniquement besoin de parcourir une fiche pour s'en imprégner, d'autres éprouveront le besoin d'exécuter des exemples de code pour se les approprier. C'est pourquoi la documentation `utilitR` propose un grand nombre d'exemples **reproductibles**. Cela signifie qu'en chargeant les _packages_ indiqués dans chaque fiche, le lecteur pourra exécuter le code des exemples présentés et reproduire le même résultat.
 
@@ -116,7 +91,7 @@ resultat
 <!-- Outre le fait de pouvoir vérifier que le code fonctionne bien sur son poste, un exemple reproductible offre la possibilité de pouvoir expérimenter par soi-même : modifications des paramètres d'une fonction, des données, etc. Il est par ailleurs reconnu que le fait d'avoir une attitude active (reproduire voire expérimenter) peut permettre de mieux assimiler qu'avec une seule lecture. -->
 <!-- ::: -->
 
-### Le package `doremifasolData`
+## Le package `doremifasolData`
 
 **Afin de se rapprocher le plus possible des situations de travail rencontrées par les agents de l'Insee, la plupart des exemples de la documentation `utilitR` reposent sur des données produites par l'Insee.** Ces données sont soit directement disponibles sur le site de l'Insee, soit construites à partir de données disponibles sur le site de l'Insee. 
 
@@ -171,6 +146,3 @@ Le _package_ `doremifasolData` n'est pas disponible sur le répertoire central d
     ```{r, eval = FALSE}
     remotes::install_github("InseeFrLab/doremifasolData", ref = "main")
     ```
-
-
-

--- a/css/default-fonts.css
+++ b/css/default-fonts.css
@@ -46,6 +46,9 @@ body {
 blockquote {
   font-family: "Linux Libertine", Palatino, serif;
 }
+h1, h2, h3, h4 {
+  font-family: "Linux Libertine", Palatino, serif;
+}
 code {
   font-family: "Courier Prime", Inconsolata, "Source Code Pro", monospace;
 }

--- a/index.Rmd
+++ b/index.Rmd
@@ -26,35 +26,20 @@ links-to-footnotes: true
 
 `r colorize("VERSION TEMPORAIRE VOUEE A EVOLUER", "red")`
 
-## Quel est l'objectif du projet `utilitR` ? {-}
+## Quel est l'objectif d'`utilitR` ? {-}
 
 **Le projet `utilitR` vise à produire une documentation collaborative et _open source_ sur `R`, destinée en premier lieu aux agents de l'Insee.** Ce projet est parti du constat qu'il est difficile d'apprendre à utiliser `R` pour de multiples raisons : multiplicité de _packages_ faisant plus ou moins la même chose, abondance et éclatement de la documentation (souvent en anglais), difficultés supplémentaires pour effectuer des choix éclairés et adaptés à l'environnement informatique de travail...
 
 Les contributeurs du projet `utilitR` se sont fixés pour objectif de **rassembler  dans un seul document tous les éléments utiles pour l'usage de `R` à l'Insee, en cherchant à couvrir la plupart des cas d'usage courants.** Cette documentation a donc été élaborée en tenant compte du contexte de travail propre à l'Institut. Cette documentation peut évidemment contenir des éléments pertinents pour un usage de `R` en dehors de l'Insee, mais ce n'est pas sa finalité première.
 
-## Que contient la documentation `utilitR` ? {-}
-
-**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. Elle veille en outre à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS). En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
-
-Cette documentation a pour ambition de répondre à deux questions générales :
-
-* Comment travailler avec `R` à l'Insee ?
-* Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
-
-Trois points importants sont à noter :
-
-* **Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee**. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
-* Cette documentation ne prétend pas être exhaustive ou sans erreurs. **Elle doit être vue comme une mise en commun des connaissances sur `R` que les agents de la statistique publique ont accumulées dans le cadre de leurs activités.**
-* **Cette documentation recommande d'utiliser `R` avec  RStudio**, qui apparaît comme la solution la plus simple et la plus complète pour un usage courant de `R`, et qui est par ailleurs le choix effectué par l'Insee.
-
-## Quelle est la spécificité du projet `utilitR` ? {-}
+## Quelle est la spécificité d'`utilitR` ? {-}
 
 **Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, porté par des agents de l'Insee et du Système Statistique Public (SSP).**
 Toute personne qui le souhaite peut modifier la documentation ou la compléter en fonction de ses connaissances et de ses expériences (voir [Comment contribuer au projet `utilitR`]).
 
 Le code source de cette documentation est hébergé sous `Github` et est accessible en cliquant sur [ce lien](https://github/InseeFrLab/utilitR).
 
-## Comment contribuer au projet `utilitR` {-}
+## Comment contribuer à `utilitR`? {-}
 
 **Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Le dépôt de la documentation est situé à [cette adresse](https://github.com/InseeFrLab/utilitR). Les objectifs et l'approche collaborative du projet `utilitR` sont détaillés dans le document `Manifeste.md`.
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -62,7 +62,7 @@ Le code source de cette documentation est hébergé sous
 
 **Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).
 
-## Section à améliorer (faire une page sur les contributeurs?)
+## Section à améliorer (faire une page sur les contributeurs?) {-}
 
 ```{r, include = FALSE}
 liste_contrib <- data.table::data.table(
@@ -83,8 +83,9 @@ liste_contrib <- liste_contrib[, c("prenom","nom") := data.table::tstrsplit(
 )][order(get("nom"))]
 ```
 
-*Ont contribué à cette documentation* :
-`r paste(liste_contrib$pseudo, collapse = ", ")`
+Contributeurs: `r paste0(paste(liste_contrib$pseudo, collapse = ", "), ".")`
+
+Coordination: `Lino Galania, Olivier Meslin.`
 
 
 ```{r include = FALSE}

--- a/index.Rmd
+++ b/index.Rmd
@@ -17,9 +17,9 @@ favicon: resources/logo-utilitr.png
 
 # Une documentation collaborative développée à l'Insee {-}
 
-```{=html}
-<a href='https://www.utilitr.org'><img src='resources/logo-utilitr.png' align="right" height="139px" /></a>
-```
+<!-- ```{=html} -->
+<!-- <a href='https://www.utilitr.org'><img src='resources/logo-utilitr.png' align="right" height="139px" /></a> -->
+<!-- ``` -->
 
 `r colorize("VERSION TEMPORAIRE VOUEE A EVOLUER", "red")`
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -41,7 +41,7 @@ Cette documentation a pour ambition de répondre à deux questions générales :
 * Comment travailler avec `R` à l'Insee ?
 * Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
 
-Deux points importants sont à noter :
+Trois points importants sont à noter :
 
 * **Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee**. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
 * Cette documentation ne prétend pas être exhaustive ou sans erreurs. **Elle doit être vue comme une mise en commun des connaissances sur `R` que les agents de la statistique publique ont accumulées dans le cadre de leurs activités.**

--- a/index.Rmd
+++ b/index.Rmd
@@ -63,7 +63,7 @@ Le code source de cette documentation est hébergé sous
 
 ## Section à améliorer (faire une page sur les contributeurs?)
 
-```{r, include=FALSE}
+```{r, include = FALSE}
 liste_contrib <- data.table::data.table(
   pseudo = c("Raphaële Adjerad", "Alexis Eidelman",
              "Antoine Dreyer", "Arthur Cazaubiel",
@@ -86,7 +86,7 @@ liste_contrib <- liste_contrib[, c("prenom","nom") := data.table::tstrsplit(
 `r paste(liste_contrib$pseudo, collapse = ", ")`
 
 
-```{r include=FALSE}
+```{r include = FALSE}
 # automatically create a bib database for R packages
 knitr::write_bib(c(
   .packages(), 'bookdown', 'knitr', 'rmarkdown'

--- a/index.Rmd
+++ b/index.Rmd
@@ -52,9 +52,7 @@ Trois points importants sont à noter :
 **Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, porté par des agents de l'Insee et du Système Statistique Public (SSP).**
 Toute personne qui le souhaite peut modifier la documentation ou la compléter en fonction de ses connaissances et de ses expériences (voir [Comment contribuer au projet `utilitR`]).
 
-Le code source de cette documentation est hébergé sous
-`Github` et est accessible en cliquant sur
-[ce lien](https://github/InseeFrLab/utilitR).
+Le code source de cette documentation est hébergé sous `Github` et est accessible en cliquant sur [ce lien](https://github/InseeFrLab/utilitR).
 
 ## Comment contribuer au projet `utilitR` {-}
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -62,7 +62,7 @@ Le code source de cette documentation est hébergé sous
 
 **Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).
 
-## Section à améliorer (faire une page sur les contributeurs?) {-}
+## Contributeurs du projet {-}
 
 ```{r, include = FALSE}
 liste_contrib <- data.table::data.table(
@@ -83,9 +83,9 @@ liste_contrib <- liste_contrib[, c("prenom","nom") := data.table::tstrsplit(
 )][order(get("nom"))]
 ```
 
-Contributeurs: `r paste0(paste(liste_contrib$pseudo, collapse = ", "), ".")`
+Ont contribué au projet `utilitR` : `r paste0(paste(liste_contrib$pseudo, collapse = ", "), ".")`
 
-Coordination: `Lino Galania, Olivier Meslin.`
+Coordination : Lino Galiana, Olivier Meslin.
 
 
 ```{r include = FALSE}

--- a/index.Rmd
+++ b/index.Rmd
@@ -82,8 +82,8 @@ La documentation `UtilitR` s'attache à être cohérente avec les recommandation
 Dans le futur, d'autres ressources liées à `R`, hébergées sur le site [www.utilitr.org](https://www.utilitr.org) pourront être proposées.
 
 
-## Comment contribuer à la documentation {-}
+## Comment contribuer au projet `utilitR` {-}
 
-**Le projet `UtilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Les objectifs et l'approche collaborative du projet `UtilitR` sont détaillés dans [ce document](LIEN VERS LE MANIFESTE).
+**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Le dépôt de la documentation est situé à [cette adresse](https://github.com/InseeFrLab/utilitR). Les objectifs et l'approche collaborative du projet `utilitR` sont détaillés dans le document `Manifeste.md`.
 
-**Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues: compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Le dépôt de la documentation est situé [ici](https://gitlab.com/linogaliana/documentationR). Tout agent intéressé à contribuer au projet est invité à consulter le [guide des contributeurs](CONTRIBUTING.md). 
+**Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).

--- a/index.Rmd
+++ b/index.Rmd
@@ -12,6 +12,7 @@ subparagraph: true
 cover-image: "resources/logo-utilitr.png"
 description: "UtilitR : Une documentation utile à R"
 favicon: resources/logo-utilitr.png
+links-to-footnotes: true
 ---
 
 

--- a/index.Rmd
+++ b/index.Rmd
@@ -15,14 +15,53 @@ favicon: resources/logo-utilitr.png
 ---
 
 
-# Une documentation collaborative développée à l'Insee {-}
 
 <!-- ```{=html} -->
 <!-- <a href='https://www.utilitr.org'><img src='resources/logo-utilitr.png' align="right" height="139px" /></a> -->
 <!-- ``` -->
 
+
+# Présentation du projet `utilitR` {-}
+
 `r colorize("VERSION TEMPORAIRE VOUEE A EVOLUER", "red")`
 
+## Quel est l'objectif du projet `utilitR` ? {-}
+
+**Le projet `utilitR` vise à produire une documentation collaborative et _open source_ sur `R`, destinée en premier lieu aux agents de l'Insee.** Ce projet est parti du constat qu'il est difficile d'apprendre à utiliser `R` pour de multiples raisons : multiplicité de _packages_ faisant plus ou moins la même chose, abondance et éclatement de la documentation (souvent en anglais), difficultés supplémentaires pour effectuer des choix éclairés et adaptés à l'environnement informatique de travail...
+
+Les contributeurs du projet `utilitR` se sont fixés pour objectif de **rassembler  dans un seul document tous les éléments utiles pour l'usage de `R` à l'Insee, en cherchant à couvrir la plupart des cas d'usage courants.** Cette documentation a donc été élaborée en tenant compte du contexte de travail propre à l'Institut. Cette documentation peut évidemment contenir des éléments pertinents pour un usage de `R` en dehors de l'Insee, mais ce n'est pas sa finalité première.
+
+## Que contient la documentation `utilitR` ? {-}
+
+**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. Elle veille en outre à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS). En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
+
+Cette documentation a pour ambition de répondre à deux questions générales :
+
+* Comment travailler avec `R` à l'Insee ?
+* Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
+
+Deux points importants sont à noter :
+
+* **Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee**. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
+* Cette documentation ne prétend pas être exhaustive ou sans erreurs. **Elle doit être vue comme une mise en commun des connaissances sur `R` que les agents de la statistique publique ont accumulées dans le cadre de leurs activités.**
+* **Cette documentation recommande d'utiliser `R` avec  RStudio**, qui apparaît comme la solution la plus simple et la plus complète pour un usage courant de `R`, et qui est par ailleurs le choix effectué par l'Insee.
+
+## Quelle est la spécificité du projet `utilitR` ? {-}
+
+**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, porté par des agents de l'Insee et du Système Statistique Public (SSP).**
+Toute personne qui le souhaite peut modifier la documentation ou la compléter en fonction de ses connaissances et de ses expériences (voir [Comment contribuer au projet `utilitR`]).
+
+Le code source de cette documentation est hébergé sous
+`Github` et est accessible en cliquant sur
+[ce lien](https://github/InseeFrLab/utilitR).
+
+## Comment contribuer au projet `utilitR` {-}
+
+**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Le dépôt de la documentation est situé à [cette adresse](https://github.com/InseeFrLab/utilitR). Les objectifs et l'approche collaborative du projet `utilitR` sont détaillés dans le document `Manifeste.md`.
+
+**Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).
+
+## Section à améliorer (faire une page sur les contributeurs?)
 
 ```{r, include=FALSE}
 liste_contrib <- data.table::data.table(
@@ -53,37 +92,3 @@ knitr::write_bib(c(
   .packages(), 'bookdown', 'knitr', 'rmarkdown'
 ), 'packages.bib')
 ```
-
-Le code source de cette documentation est hebergé sous
-`Gitlab` et est
-[accessible en cliquant sur ce lien](https://gitlab.com/linogaliana/documentationR)
-
-## Objectifs de la documentation `UtilitR` {-}
-
-**Cette documentation s'adresse à tous les agents de l'Insee dans le cadre d'un usage courant de `R`.** Elle est conçue pour aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents). Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
-
-Cette documentation a pour ambition de répondre à trois questions générales :
-
-* Comment travailler avec `R` à l'Insee ?
-* Comment réaliser des tâches standards avec `R` (importation et manipulation de données, exploitation d'enquêtes, graphiques...) ?
-* Quelles sont les bonnes pratiques à respecter pour bien utiliser `R` ?
-
-Deux points importants sont à noter :
-
-* __Cette documentation recommande les outils et les *packages* les plus adaptés au contexte d'utilisation de `R` à l'Insee__. Ces recommandations ne sont pas nécessairement adaptées à d'autres contextes, et pourront évoluer lorsque ce contexte évoluera.
-* __Cette documentation recommande d'utiliser `R` avec `Rstudio`__, qui apparaît comme la solution la plus simple et la plus complète pour un usage courant de `R`.
-
-## Quelle est la place du projet `UtilitR` à l'Insee ? {-}
-
-**Le projet `UtilitR` est porté par les agents de l'Insee ou de Système Statistique Publique (SSP) de manière collaborative**.
-
-Le projet `UtilitR` propose en premier lieu une documentation sur le logiciel `R`.
-La documentation `UtilitR` s'attache à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS).
-Dans le futur, d'autres ressources liées à `R`, hébergées sur le site [www.utilitr.org](https://www.utilitr.org) pourront être proposées.
-
-
-## Comment contribuer au projet `utilitR` {-}
-
-**Le projet `utilitR` est un projet collaboratif, évolutif, *open source* et ouvert à tous, auquel tous les agents peuvent contribuer.** Le projet est mené par un groupe de contributeurs qui en définissent eux-mêmes le contenu, la structure et le calendrier. Le dépôt de la documentation est situé à [cette adresse](https://github.com/InseeFrLab/utilitR). Les objectifs et l'approche collaborative du projet `utilitR` sont détaillés dans le document `Manifeste.md`.
-
-**Tout agent qui le souhaite peut modifier ou compléter la documentation en fonction de ses connaissances et de ses expériences**, et toutes les contributions sont les bienvenues : compléments, corrections d'erreur, améliorations, questions... Il n'y a aucun prérequis, et aucun niveau minimal en `R` n'est demandé. Tout agent intéressé à contribuer au projet est invité à consulter le guide des contributeurs (`CONTRIBUTING.md`).

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,6 +1,6 @@
 --- 
-title: "`UtilitR` : Une documentation sur `R` à l'usage des statisticiens publics"
-author: "Une documentation collaborative coordonnée par Lino Galiana et Olivier Meslin"
+title: "`UtilitR`"
+author: "Une documentation sur `R` à l'usage des statisticiens publics"
 date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
 documentclass: book


### PR DESCRIPTION
L'introduction et le chapitre 1 comprenaient beaucoup de paragraphes dupliqués. J'ai recentré l'introduction sur la présentation du projet, et la première fiche sur l'utilisation de la documentation. Pas sûr que tout soit cohérent.