### PR TITLE
option include au lieu de echo

### DIFF
--- a/03_Fiches_thematiques/Fiche_donnees_spatiales.Rmd
+++ b/03_Fiches_thematiques/Fiche_donnees_spatiales.Rmd
@@ -1,6 +1,6 @@
 # Manipuler des données spatiales {#spatdata}
 
-```{r, echo = FALSE}
+```{r, include = FALSE}
 library(magrittr)
 ```
 


### PR DESCRIPTION
Pour empêcher l'apparition au début du document de :

```
## 
## Attaching package: 'magrittr'

## The following object is masked from 'package:tidyr':
## 
##     extract
```