### PR TITLE
Ajout outil mc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,11 @@ RUN apt-get update && \
 
 RUN whereis google-chrome
 
+# Installing mc
+
+RUN wget https://dl.min.io/client/mc/release/linux-amd64/mc -O /usr/local/bin/mc && \
+    chmod +x /usr/local/bin/mc
+
 # Change right permissions (see https://github.com/rocker-org/rocker-versioned/issues/104)
 # RUN  chown -R root:staff /opt/texlive \
 #   && chown -R root:staff /usr/local/texlive \


### PR DESCRIPTION
Pour communiquer avec le minio du SSP Cloud (je l'utilise pour des scripts d'initialisation de RStudio).

## Checklist:

En faisant cette *pull request*, je confirme que :

- [X] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [X] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`bookdown::render_book("index.Rmd", output_dir = "_public", output_format = "utilitr::bs4_utilitr")`
produit un résultat
- [X] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://www.${BRANCH_NAME}--preview-docr.netlify.app/`

