### PR TITLE
redesign dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,11 @@ FROM rocker/geospatial:4.0.4
 
 # R packages 
 COPY ./DESCRIPTION /tmp/build_image/
-RUN Rscript -e "install.packages(c('xfun','knitr'))"
+RUN Rscript -e "install.packages(c('xfun','knitr', 'insee', 'OECD'))"
 RUN Rscript -e "remotes::install_deps('/tmp/build_image', dependencies = TRUE, upgrade = FALSE)"
 RUN Rscript -e "remotes::install_github('rstudio/bookdown')"
+RUN Rscript -e "remotes::install_github('inseefrlab/inseelocaldata')"
+RUN Rscript -e "remotes::install_github('inseefrlab/doremifasol')"
 
 RUN apt-get update \
     && apt-get -qq install gnupg \


### PR DESCRIPTION
Réécriture du dockerfile, en abandonnant la partie double-stage build qui tel qu'est le Dockerfile actuel, ne me semble pas utile.
Ajout de l'installation de _bookdown_ depuis le dépôt Github Rstudio.

## Checklist:

En faisant cette *pull request*, je confirme que :

- [X] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [X] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`bookdown::render_book("index.Rmd", output_dir = "_public", output_format = "utilitr::bs4_utilitr")`
produit un résultat
- [X] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://www.${BRANCH_NAME}--preview-docr.netlify.app/`

