### PR TITLE
supprime mention COPS

### DIFF
--- a/01_R_Insee/Fiche_utiliser_utilitR.Rmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.Rmd
@@ -2,7 +2,7 @@
 
 ## Contenu de la documentation
 
-**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. Elle veille en outre à être cohérente avec les recommandations émises par le comité de certification des _packages_ `R` (COPS). En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
+**Cette documentation vise à aider les agents à réaliser des traitements statistiques usuels avec `R` et à produire des sorties (graphiques, cartes, documents).** Cette documentation présente succinctement les outils les plus adaptés à ces tâches, et oriente les agents vers les ressources documentaires pertinentes. En revanche, elle n'aborde pas les outils les plus avancés, notamment ceux utilisés dans un cadre de développement logiciel.
 
 <!-- Cette documentation a pour ambition de répondre à deux questions générales : -->
 


### PR DESCRIPTION
La phrase supprimée sur le COPS est spécifique à l'Insee. Je trouve aussi que cette information arrive beaucoup trop tôt dans la lecture par rapport à son importance en pratique. J'ai donc opté pour une suppression pure et simple.

À discuter.
