### PR TITLE
Ajout "à la main" du numéro de version d'utilitR

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -36,7 +36,7 @@ jobs:
           GITHUB_PAT: ${{ secrets.PAT }}
         with:
           push: true
-          tags: inseefrlab/utilitr:latest
+          tags: inseefrlab/utilitr:0.7.0
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -44,7 +44,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     needs: docker
     runs-on: ubuntu-latest
-    container: inseefrlab/utilitr:latest
+    container: inseefrlab/utilitr:0.7.0
     steps:
       - name: Checkout Repository
         env:
@@ -78,7 +78,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     runs-on: ubuntu-latest
     needs: docker
-    container: inseefrlab/utilitr:latest
+    container: inseefrlab/utilitr:0.7.0
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -36,7 +36,8 @@ jobs:
           GITHUB_PAT: ${{ secrets.PAT }}
         with:
           push: true
-          tags: inseefrlab/utilitr:0.7.0
+          image: inseefrlab/utilitr
+          tags: latest, 0.7.0
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -44,7 +45,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     needs: docker
     runs-on: ubuntu-latest
-    container: inseefrlab/utilitr:0.7.0
+    container: inseefrlab/utilitr:latest
     steps:
       - name: Checkout Repository
         env:
@@ -78,7 +79,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     runs-on: ubuntu-latest
     needs: docker
-    container: inseefrlab/utilitr:0.7.0
+    container: inseefrlab/utilitr:latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@master

--- a/01_R_Insee/Fiche_utiliser_Rstudio_SSPCloud.Rmd
+++ b/01_R_Insee/Fiche_utiliser_Rstudio_SSPCloud.Rmd
@@ -5,7 +5,7 @@ Vous pouvez utiliser `R` et RStudio sur le SSP Cloud pour mener des expérimenta
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 ## Présentation succincte du SSP Cloud

--- a/03_Fiches_thematiques/Fiche_datatable.Rmd
+++ b/03_Fiches_thematiques/Fiche_datatable.Rmd
@@ -10,7 +10,7 @@ L'utilisateur souhaite manipuler des données stucturées sous forme de `data.fr
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 ## Présentation de `data.table`

--- a/03_Fiches_thematiques/Fiche_graphiques.Rmd
+++ b/03_Fiches_thematiques/Fiche_graphiques.Rmd
@@ -10,7 +10,7 @@ L'utilisateur souhaite réaliser des graphiques (nuages de points, histogrammes,
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 

--- a/03_Fiches_thematiques/Fiche_import_tableurs.Rmd
+++ b/03_Fiches_thematiques/Fiche_import_tableurs.Rmd
@@ -5,7 +5,7 @@
 L'utilisateur souhaite importer dans `R` des données issues de tableurs (extension type `xls`, `xlsx` ou `ods`).
 
 ::: {.recommandation}
-- **Il est recommandé d'utiliser la fonction `read_xlsx()` du _package_ `openxlsx` pour importer des fichiers `xlsx`.**
+- **Il est recommandé d'utiliser la fonction `read.xlsx()` du _package_ `openxlsx` pour importer des fichiers `xlsx`.**
 - **Il est recommandé d'utiliser la fonction `read_excel()` du _package_ `readxl` pour importer des fichiers `xls`.** Cette fonction peut également importer des fichiers `xlsx`, mais elle est moins rapide que la fonction `read_xlsx()` du _package_ `openxlsx`.
 - **Il est recommandé d'utiliser la fonction `read_ods` du _package_ `readODS` pour importer des fichiers `ods`.**
 

--- a/03_Fiches_thematiques/Fiche_joindre_donnees.Rmd
+++ b/03_Fiches_thematiques/Fiche_joindre_donnees.Rmd
@@ -11,7 +11,7 @@ Vous souhaitez apparier deux tables de données selon une ou plusieurs variables
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 ## Les différents types de jointure

--- a/03_Fiches_thematiques/Fiche_rmarkdown.Rmd
+++ b/03_Fiches_thematiques/Fiche_rmarkdown.Rmd
@@ -11,7 +11,7 @@ L'utilisateur souhaite produire avec `R` des documents contenant à la fois du t
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 ## Présentation générale de `R Markdown`

--- a/03_Fiches_thematiques/Fiche_tidyverse.Rmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.Rmd
@@ -12,7 +12,7 @@ L'utilisateur souhaite manipuler des données stucturées sous forme de `data.fr
 :::
 
 ::: {.remarque}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consulter la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
+Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
 :::
 
 ## Présentation des _packages_ `dplyr`, `tidyr` et `tibble`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: documentationR
 Type: Book
 Title: Documentation R de l'Insee
-Version: 0.0.0.9000
+Version: 0.7.0
 Description: Ce dépôt comprend les fichiers relatifs à la 
     documentation R de l'Insee.
 Authors@R: c(


### PR DESCRIPTION
Ajout de la numéro de version pour une gestion par le tag de l'image Docker, mise en cohérence avec le numéro de version de la documentation

## Checklist:

En faisant cette *pull request*, je confirme que :

- [X] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [X] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`bookdown::render_book("index.Rmd", output_dir = "_public", output_format = "utilitr::bs4_utilitr")`
produit un résultat
- [X] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://www.${BRANCH_NAME}--preview-docr.netlify.app/`

