### PR TITLE
désactive warning chargement readr

### DIFF
--- a/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
+++ b/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
@@ -21,7 +21,7 @@ Le *package* `readr` propose plusieurs fonctions adaptées pour importer des fic
 Il faut charger le *package* `readr` pour utiliser ces fonctions :
 
 ```{r} 
-library(readr)
+library(readr, warning = FALSE)
 ```
 
 ::: {.conseil}

--- a/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
+++ b/03_Fiches_thematiques/Fiche_import_fichiers_plats.Rmd
@@ -20,8 +20,8 @@ Le *package* `readr` propose plusieurs fonctions adaptées pour importer des fic
 
 Il faut charger le *package* `readr` pour utiliser ces fonctions :
 
-```{r} 
-library(readr, warning = FALSE)
+```{r, include = FALSE} 
+library(readr)
 ```
 
 ::: {.conseil}
@@ -190,7 +190,6 @@ Voici quelques bonnes pratiques à avoir en tête pour importer des données :
     
 * sur `data.table` :
     - la [documentation du *package*](https://www.rdocumentation.org/packages/data.table) (en anglais).
-
 
 
 


### PR DESCRIPTION
Méchants warnings au chargement de readr : 
```r
library(readr)

## Warning: replacing previous import 'ellipsis::check_dots_unnamed' by
## 'rlang::check_dots_unnamed' when loading 'hms'

## Warning: replacing previous import 'ellipsis::check_dots_used' by
## 'rlang::check_dots_used' when loading 'hms'

## Warning: replacing previous import 'ellipsis::check_dots_empty' by
## 'rlang::check_dots_empty' when loading 'hms'
```

Ne sachant pas exactement la cause, je propose de les cacher.