### PR TITLE
install jq et correctif depot google

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,17 +25,19 @@ RUN apt-get update \
        libgs-dev \
        librsvg2-dev \
        libwebp-dev \
+       jq \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /src/*.deb \
-    && apt-get upgrade -y
+    && rm -rf /src/*.deb
 
 RUN apt-get update && \
   apt-get -yq install wget apt-transport-https ca-certificates gnupg --no-install-recommends && \
   apt-get -yq install libgconf-2-4 && \
   wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
-  sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' &&\
+  sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list' &&\
   apt-get update && \
-  apt-get -yq install google-chrome-stable --no-install-recommends 
+  apt-get -yq install google-chrome-stable --no-install-recommends &&\
+  apt-get upgrade -y &&\
+  apt-get autoremove -y
 
 # Installing mc
 


### PR DESCRIPTION
Correction de la spécification du dépôt google qui rendait impossible la mise à jour, et installation du paquet jq