### PR TITLE
Correction coquilles dans is_odd

### DIFF
--- a/03_Fiches_thematiques/Fiche_comment_choisir_un_package.Rmd
+++ b/03_Fiches_thematiques/Fiche_comment_choisir_un_package.Rmd
@@ -93,14 +93,14 @@ présentant des bugs et éventuellement des failles de sécurité. Le premier co
 
 On peut illustrer ces extrêmes au travers de deux exemples de tâches :
 
-- on veut tester si un vecteur numérique comprend des nombres pairs ; il serait
+- on veut tester si un vecteur numérique comprend des nombres impairs ; il serait
 inopportun d'utiliser la fonction `is.odd()` du _package_
 [`FSA`](https://cran.r-project.org/package=FSA) alors qu'elle peut simplement
 s'écrire :
   
   ``` r
   is_odd <- function(x) {
-    x %% 2 == 0
+    x %% 2 != 0
   }
  ```
 


### PR DESCRIPTION
La fonction `is_odd()` retournait `TRUE` pour les valeurs paires et `FALSE` pour les valeurs impaires, alors que ça doit être l'inverse.

## Checklist:

En faisant cette *pull request*, je confirme que :

- [x] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [x] Ma proposition respecte les canons formels de la documentation `utilitR`
- [x] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`bookdown::render_book("index.Rmd", output_dir = "_public", output_format = "utilitr::bs4_utilitr")`
produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://www.${BRANCH_NAME}--preview-docr.netlify.app/`

