### PR TITLE
Remplacement fonction ods_sheets() par list_ods_sheets()

### DIFF
--- a/03_Fiches_thematiques/Fiche_import_tableurs.Rmd
+++ b/03_Fiches_thematiques/Fiche_import_tableurs.Rmd
@@ -259,9 +259,9 @@ mesDonnees <- readODS::read_ods(path = chemin_ods, sheet = "Sheet3")
 ```
 
 ::: {.remarque}
-La fonction `readODS::ods_sheets()` permet de récupérer les noms des onglets du fichier sans avoir à l'ouvrir.
+La fonction `readODS::list_ods_sheets()` permet de récupérer les noms des onglets du fichier sans avoir à l'ouvrir.
 ```{r}
-readODS::ods_sheets(chemin_ods)
+readODS::list_ods_sheets(chemin_ods)
 ```
 :::
 


### PR DESCRIPTION
PR pour remplacer la fonction `readODS::ods_sheets()` (dépréciée) par `readODS::list_ods_sheets()`