### PR TITLE
Correction on docker image (#441)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Il est possible de contribuer au projet `utilitR` de différentes manières, dé
 des contributeurs actuels, fonctionnement qui est orchestré autour de `Github` et de ses différents outils.
 Il est possible d'en acquérir très rapidement les bases à partir de ce document présentant le [Travail collaboratif avec `R`](https://linogaliana.gitlab.io/collaboratif/git.html#des-bases-de-git), ou à partir d'échanges avec les contributeurs actuels.
 
-Un environnement prêt à l'emploi pour l'exécution des scripts est disponible sur le `SSPCloud`. En cliquant sur le lien suivant, un service `RStudio` avec l'ensemble des dépendances nécessaires pour utiliser la documentation est disponible: [![SSPcloud](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB)
+Un environnement prêt à l'emploi pour l'exécution des scripts est disponible sur le `SSPCloud`. En cliquant sur le lien suivant, un service `RStudio` avec l'ensemble des dépendances nécessaires pour utiliser la documentation est disponible: [![SSPcloud](https://img.shields.io/badge/SSPcloud-Tester%20via%20SSP--cloud-informational?logo=R)](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB)
 
 Pour les relecteurs quelques notions de l'environnement `Github` suffisent
 (ou peuvent s'acquérir facilement) pour apporter sa pierre à l'édifice.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,11 @@ FROM inseefrlab/onyxia-rstudio:latest
 
 # R packages 
 COPY ./DESCRIPTION /tmp/build_image/
-RUN Rscript -e "install.packages(c('xfun','knitr', 'insee', 'OECD'))"
+RUN Rscript -e "install.packages(c('xfun','knitr', 'insee', 'OECD', 'htmltools'))"
 RUN Rscript -e "remotes::install_deps('/tmp/build_image', dependencies = TRUE, upgrade = FALSE)"
 RUN Rscript -e "remotes::install_github('kevinushey/rex')"
 RUN Rscript -e "remotes::install_github('rstudio/bookdown')"
 RUN Rscript -e "remotes::install_github('inseefrlab/inseelocaldata')"
-RUN Rscript -e "remotes::install_github('inseefrlab/doremifasol', build_vignettes = TRUE)"
 
 RUN apt-get update \
     && apt-get -qq install gnupg

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ encapsulé dans un *package* `R` dédié: https://github.com/InseeFrLab/utilitr-
 
 L'ensemble des ressources du projet `utilitR` sont disponibles sur https://www.utilitr.org
 
-Un environnement prêt à l'emploi est disponible pour les utilisateurs du `SSPCloud` en cliquant
-sur le [lien suivant](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB) [![SSPcloud](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB)
+Un environnement prêt à l'emploi est disponible pour les utilisateurs du `SSPCloud` en cliquant sur le [lien suivant](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB) [![SSPcloud](https://img.shields.io/badge/SSPcloud-Tester%20via%20SSP--cloud-informational?logo=R)](https://datalab.sspcloud.fr/launcher/ide/rstudio?autoLaunch=false&init.personalInit=%C2%ABhttps%3A%2F%2Fgithub.com%2FInseeFrLab%2FutilitR%2Fblob%2Fmaster%2Finit_utilitr.sh%C2%BB&service.image.custom.enabled=true&service.image.custom.version=%C2%ABinseefrlab%2Futilitr%3Alatest%C2%BB)
 
 <br>
 


### PR DESCRIPTION
* Dockerfile: switch to onyxia-rstudio image

* change init script

* up to 0.9.0 version for Docker image

* correct init_utilitr.sh

* correction (new) init_utilitr.sh

* correction init_utilitr.sh

* Update of launching links

* update launching links

* update packages in dockerfile

* Update Dockerfile

* stop bulk update and install only new version of htmltools

* retire doremifasol

Co-authored-by: Lino Galiana <33896139+linogaliana@users.noreply.github.com>

**Compléter une description indicative ici.**

Si la modification est associée à une *issue*, elle peut être identifiée par son numéro, par exemple `#10`.

Pour fermer automatiquement une *issue* lorsque la `pull request` sera validée, marquer

```markdown
`close #XX`
```

en remplaçant  `#XX` par le numéro de l'*issue* (par exemple `#10`)

## Checklist:

En faisant cette *pull request*, je confirme que :

- [ ] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [ ] Ma proposition respecte les canons formels de la documentation `utilitR`
- [ ] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`bookdown::render_book("index.Rmd", output_dir = "_public", output_format = "utilitr::bs4_utilitr")`
produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://www.${BRANCH_NAME}--preview-docr.netlify.app/`

