### PR TITLE
Ajout lien vers le chapitre des expressions régulières du livre "R for Datascience"

### DIFF
--- a/03_Fiches_thematiques/Fiche_donnees_textuelles.Rmd
+++ b/03_Fiches_thematiques/Fiche_donnees_textuelles.Rmd
@@ -471,6 +471,7 @@ Beaucoup de fonctions disponibles dans `stringi` et `stringr` sont en réalité 
     - une [vignette](https://cran.r-project.org/web/packages/stringr/vignettes/regular-expressions.html) sur les expressions régulières avec `stringr` (en anglais) ;
     - la [partie `stringr`](https://juba.github.io/tidyverse/11-stringr.html) de l'introduction à `R` et au `tidyverse` (en français) ;
     - [un aide-mémoire en anglais sur la construction des expressions régulières avec R](https://github.com/rstudio/cheatsheets/raw/master/strings.pdf) ;
+    - [le chapitre dédié aux expressions régulières du livre `R for Data Science`](https://r4ds.hadley.nz/regexps.html) ;
 * sur le *package* `RVerbalExpressions` :
     - la [documentation](https://cran.r-project.org/web/packages/RVerbalExpressions/RVerbalExpressions.pdf) du *package* (en anglais) ;
     - une [vignette](https://cran.r-project.org/web/packages/RVerbalExpressions/vignettes/examples.html) d'exemples d'utilisation du *package* (en anglais).


### PR DESCRIPTION
Dans la fiche sur les données textuelles.

Hadley Wickham a posté sur Twitter la mise à disposition de ce chapitre cette semaine :
https://twitter.com/hadleywickham/status/1589761315475947520

close #449 


