### PR TITLE
quarto repo-branch:master

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -25,6 +25,7 @@ book:
   site-url: https://www.book.utilitr.org/
   repo-url: https://github.com/InseeFrLab/utilitR
   repo-actions: [edit,issue]
+  repo-branch: master
   cover-image: resources/logo-utilitr.png
   favicon: resources/logo-utilitr.png
 


### PR DESCRIPTION
car actuellement les boutons Edit et Source pointent sur la branche `main` (valeur par défaut dans _quarto.yml) sur le site web
