### PR TITLE
add link online documentation sspcloud

### DIFF
--- a/01_R_Insee/Fiche_utiliser_Rstudio_SSPCloud.qmd
+++ b/01_R_Insee/Fiche_utiliser_Rstudio_SSPCloud.qmd
@@ -378,4 +378,5 @@ aws.s3::s3write_using(
 
 - Le salon Tchap [SSPCloud](https://www.tchap.gouv.fr/#/room/#SSPCloudXDpAw6v:agent.finances.tchap.gouv.fr) ;
 - Le salon Tchap d'assistance aux utilisateurs des **Logiciels Statistiques et Libre Service** [Insee - Outils Stats V2](https://www.tchap.gouv.fr/#/room/#InseeOutilsStatsv2wtxSdth:agent.finances.tchap.gouv.fr) ;
-- un [tutoriel sur le SSP Cloud](https://github.com/RLesur/sspcloud-demo).
+- Un [tutoriel sur le SSP Cloud](https://github.com/RLesur/sspcloud-demo).
+- La [documentation en ligne du Datalab](https://docs.sspcloud.fr/)


### PR DESCRIPTION
Ajout de lien de la [doc en ligne du Datalab](https://datalab.sspcloud.fr/) à la page 29 (*Utiliser RStudio sur l’environnement SSP Cloud*)