### PR TITLE
Ajoute infos sur l'opérateur :: dans la fiche packages

### DIFF
--- a/01_R_Insee/Fiche_installer_packages.qmd
+++ b/01_R_Insee/Fiche_installer_packages.qmd
@@ -175,7 +175,7 @@ Il ne faut pas essayer d'installer des _packages_ en cliquant sur le bouton <kbd
 
 ## Utiliser un _package_ `R`
 
-**Une fois qu'un _package_ est installé sur votre machine, il est nécessaire de procéder au chargement du _package_ avec la fonction `library()` pour pouvoir l'utiliser.** Charger un _package_ consiste à indiquer à `R` que l'on souhaite utiliser le _package_ dans la session courante. Par exemple, pour charger le _package_ `ggplot2`, il est nécessaire d'exécuter la commande suivante :
+**Une fois qu'un _package_ est installé sur votre machine, il est pratique de procéder au chargement du _package_ avec la fonction `library()` pour pouvoir l'utiliser.** Charger un _package_ consiste à indiquer à `R` qu'on souhaite l'utiliser dans la session courante. Ceci rend possible l'utilisation des fonctions implémentées par le _package_. Par exemple, pour charger le _package_ `ggplot2`, il est nécessaire d'exécuter la commande suivante :
 
 ```{r, eval = FALSE}
 library(ggplot2)
@@ -185,6 +185,16 @@ Par défaut, la fonction `library` cherche le _package_ dans la librairie d'inst
 
 ::: {.callout-tip}
 Il est indispensable de rassembler les instructions de chargement de _package_ au début des programmes `R`, car cela permet à un utilisateur qui ne connaît pas les programmes de repérer facilement les _packages_ utilisés.
+:::
+
+::: {.callout-note}
+Même si un _package_ n'a pas été chargé à l'aide de la fonction `library()`, il est possible d'appeler ses fonctions avec l'opérateur `::`. Par exemple, même sans avoir chargé le _package_ `ggplot2`, il est possible d'initialiser un plot avec la commande suivante :
+
+```{r, eval = FALSE}
+ggplot2::ggplot(data = df)
+```
+
+L'opérateur `::` est particulièrement utile en cas de conflits entre _packages_, comme détaillé dans la fiche sur [les bonnes pratiques pour améliorer la reproductibilité](#reproductibility).
 :::
 
 ## Pour en savoir plus

--- a/01_R_Insee/Fiche_installer_packages.qmd
+++ b/01_R_Insee/Fiche_installer_packages.qmd
@@ -194,7 +194,7 @@ Même si un _package_ n'a pas été chargé à l'aide de la fonction `library()`
 ggplot2::ggplot(data = df)
 ```
 
-L'opérateur `::` est particulièrement utile en cas de conflits entre _packages_, comme détaillé dans la fiche sur [les bonnes pratiques pour améliorer la reproductibilité](#reproductibility).
+L'opérateur `::` est particulièrement utile en cas de conflits entre _packages_, comme détaillé dans la fiche sur [les bonnes pratiques pour améliorer la reproductibilité](#reproducibility).
 :::
 
 ## Pour en savoir plus

--- a/02_Bonnes_pratiques/05-regles.qmd
+++ b/02_Bonnes_pratiques/05-regles.qmd
@@ -1,4 +1,4 @@
-# Comment renforcer la réplicabilité ?
+# Comment renforcer la réplicabilité ? {#reproductibility}
 
 ## Conflits entre *packages*
 

--- a/02_Bonnes_pratiques/05-regles.qmd
+++ b/02_Bonnes_pratiques/05-regles.qmd
@@ -1,4 +1,4 @@
-# Comment renforcer la réplicabilité ? {#reproductibility}
+# Comment renforcer la réplicabilité ? {#reproducibility}
 
 ## Conflits entre *packages*
 


### PR DESCRIPTION
Ajoute dans la fiche sur l'installation et l'import de packages une note sur l'utilisation de `::`.

Closes #375 
