### PR TITLE
Répare les liens cassés qui vont de la fiche 'tidyverse' à la fiche '…

### DIFF
--- a/03_Fiches_thematiques/Fiche_tidyverse.qmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.qmd
@@ -215,7 +215,7 @@ Dans `dplyr`, les manipulations simples de données sont résumées en quelques 
 | `select(starts_with("...")` | dont le nom commence par "..."  |
 | `select(ends_with("...")`   | dont le nom se termine par "..."  |
 | `select(contains("...")`    | contient "..."  |
-| `select(matches("...")`     | vérifie une expression régulière (_cf._ fiche [Manipuler des données textuelles])  |
+| `select(matches("...")`     | vérifie une expression régulière (_cf._ fiche [Manipuler des données textuelles](03_Fiches_thematiques/Fiche_donnees_textuelles.qmd)  |
 | `select(all_of(...))`       | sélectionne les colonnes listées dans un vecteur en paramètre |
 | `select(any_of(...))`       | identique à `all_of()`, mais sans erreur si la colonne n'existe pas |
 | `select(everything())`      | toutes les colonnes (utile pour mettre une nouvelle colonne devant les autres)      |
@@ -260,7 +260,7 @@ Voici quelques utilisations fréquentes de `filter()` :
 |-----------------------------------------------------------------------|-----------------------------------------|
 | Filtrer sur les modalités qualitatives d'une colonne                  | `filter(DEP %in% c("75", "92"))`                   |
 | Filtrer sur les modalités quantitatives d'une colonne                 | `filter(NB_EQUIP == 1)`                 |
-| Filtrer sur une variable caractère (voir la [fiche données textuelles](Manipuler des données textuelles)) | `filter(str_detect(TYPEQU, "^A"))`      |
+| Filtrer sur une variable caractère (voir la [fiche données textuelles](03_Fiches_thematiques/Fiche_donnees_textuelles.qmd)) | `filter(str_detect(TYPEQU, "^A"))`      |
 | Filtrer sur deux conditions (et)                                      | `filter(DEP == "75" & NB_EQUIP == 1)`   |
 | Filtrer sur une alternative (ou)                                      | `filter(DEP == "75" | NB_EQUIP == 1)`   |
 | Conserver les observations pour lesquelles la variable est manquante  | `filter(is.na(pop_2016))`               |
@@ -303,7 +303,7 @@ Voici quelques utilisations fréquentes de `mutate()` :
 | Calculer une somme cumulée                  | `mutate(NB_EQUIP_CUM = cumsum(NB_EQUIP, na.rm = TRUE))`  |
 | Calculer un total                           | `mutate(NB_EQUIP_TOT = sum(NB_EQUIP, na.rm = TRUE))`                    |
 | Sommer deux variables                       | `mutate(NB_EQUIP_DOUBLE = NB_EQUIP + NB_EQUIP)`                    |
-| Extraire une sous-chaine de caractères (voir la [fiche données textuelles](Manipuler des données textuelles))  | `mutate(CATEGORIE_EQ = str_sub(TYPEQU, 1L, 1L))`                    |
+| Extraire une sous-chaine de caractères (voir la [fiche données textuelles](03_Fiches_thematiques/Fiche_donnees_textuelles.qmd))  | `mutate(CATEGORIE_EQ = str_sub(TYPEQU, 1L, 1L))`                    |
  
 #### Calculer des statistiques : `summarise()`
  


### PR DESCRIPTION
…manipuler des données textuelles'

Suite à la remarque de PYB, nouveau commit avec le lien sous la forme : 03_Fiches_thematiques/Fiche_donnees_textuelles.qmd

<!-----------

**Compléter une description indicative ici.**

Si la modification est associée à une *issue*, elle peut être identifiée par son numéro, par exemple `#10`.

Pour fermer automatiquement une *issue* lorsque la `pull request` sera validée, marquer

```markdown
`close #XX`
```

en remplaçant  `#XX` par le numéro de l'*issue* (par exemple `#10`)

## Checklist:

En faisant cette *pull request*, je confirme que :

- [ ] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [ ] Ma proposition respecte les canons formels de la documentation `utilitR`
- [ ] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`

-------------->
