### PR TITLE
Correction bug code inline

### DIFF
--- a/01_R_Insee/presentation_utilitr.qmd
+++ b/01_R_Insee/presentation_utilitr.qmd
@@ -34,8 +34,7 @@ avec `Github`.
 
 ## Contributeurs du projet
 
-Le projet `utilitR` est un projet collaboratif qui a bénéficié des contributions de : 
-`{r} paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")`
+Le projet `utilitR` est un projet collaboratif qui a bénéficié des contributions de : `{r} paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")`
 
 La coordination est assurée par Pierre-Yves Berrard, Lino Galiana et Olivier Meslin.
 

--- a/01_R_Insee/presentation_utilitr.qmd
+++ b/01_R_Insee/presentation_utilitr.qmd
@@ -29,12 +29,21 @@ avec `Github`.
 
 ## Contributeurs du projet
 
-
 ::: {.callout-note}
 
 ## Contributeurs du projet
 
-Le projet `utilitR` est un projet collaboratif qui a bénéficié des contributions de : `{r} paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")`
+<!-- Ce chunk est indispensable pour que le code inline fonctionne -->
+<!-- cf https://github.com/quarto-dev/quarto-cli/discussions/4855 -->
+
+```{r}
+#| echo: false
+#| output: false
+#| warning: false
+liste_contributeurs <- paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")
+```
+
+Le projet `utilitR` est un projet collaboratif qui a bénéficié des contributions de : `{r} liste_contributeurs`
 
 La coordination est assurée par Pierre-Yves Berrard, Lino Galiana et Olivier Meslin.
 

--- a/01_R_Insee/presentation_utilitr.qmd
+++ b/01_R_Insee/presentation_utilitr.qmd
@@ -35,7 +35,7 @@ avec `Github`.
 ## Contributeurs du projet
 
 Le projet `utilitR` est un projet collaboratif qui a bénéficié des contributions de : 
-`r paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")`
+`{r} paste0(paste(format(Filter(function(x) !("cph" %in% x$role), desc::desc_get_authors()), include = c("given", "family")), collapse = ", "), ".")`
 
 La coordination est assurée par Pierre-Yves Berrard, Lino Galiana et Olivier Meslin.
 


### PR DESCRIPTION
Le passage de Rmarkdown à Quarto provoque des bugs sur les codes inline. Cette PR règle un problème sur la liste des contributeurs. 