### PR TITLE
Fix quarto publishing pages

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -48,15 +48,17 @@ jobs:
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
   website:
+    name: Render website
     if: "!contains(github.event.commits[0].message, '[skip ci]')"
     needs: docker
     runs-on: ubuntu-latest
     container: inseefrlab/utilitr:latest
     steps:
-      - name: Checkout Repository
-        env:
-          GITHUB_PAT: ${{ secrets.PAT }}
-        uses: actions/checkout@master
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
       - name: Install Dependencies
         run: |
           Rscript -e "install.packages(c('remotes'))"
@@ -66,7 +68,7 @@ jobs:
           GITHUB_PAT: ${{ secrets.PAT }}
       - name: Render Book
         run: |
-          quarto render
+          quarto render --to html
       - uses: actions/upload-artifact@v2
         with:
           name: _public

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -76,6 +76,8 @@ jobs:
           retention-days: 5
       - name: Publish to GitHub Pages (and render)
         run: |
+          ls
+          git remote -v
           git config --global user.email quarto-github-actions-publish@example.com
           git config --global user.name "Quarto GHA Workflow Runner"
           quarto publish gh-pages --no-render --no-browser

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - test
 
 jobs:
   docker:
@@ -75,6 +76,6 @@ jobs:
         run: |
           git config --global user.email quarto-github-actions-publish@example.com
           git config --global user.name "Quarto GHA Workflow Runner"
-          quarto publish gh-pages . --no-render --no-browser
+          quarto publish gh-pages --no-render --no-browser
         #env:
         #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-----------

**Compléter une description indicative ici.**

Si la modification est associée à une *issue*, elle peut être identifiée par son numéro, par exemple `#10`.

Pour fermer automatiquement une *issue* lorsque la `pull request` sera validée, marquer

```markdown
`close #XX`
```

en remplaçant  `#XX` par le numéro de l'*issue* (par exemple `#10`)

## Checklist:

En faisant cette *pull request*, je confirme que :

- [ ] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [ ] Ma proposition respecte les canons formels de la documentation `utilitR`
- [ ] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`

-------------->
