### PR TITLE
Comparaison cas d'usage arrow et duckdb

### DIFF
--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -74,7 +74,7 @@ Du point de vue d'un statisticien utilisant `R`, le *package* `duckdb` permet de
 
 ### Quand utiliser `duckdb` plutôt que `arrow` ?
 
-Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir la fiche [Manipuler des données avec `arrow`](#arrow)), mais on peut préférer l'un à l'autre selon les cas. On peut également les utiliser ensemble pour profiter de chacun de leurs avantages. Le tableau ci-dessous compare quelques cas d'usage de ces deux **packages** :
+Les *packages* `duckdb` et `arrow` ont des cas d'usage très similaires (voir la fiche [Manipuler des données avec `arrow`](#arrow)), mais on peut préférer l'un à l'autre selon les cas. On peut également les utiliser ensemble pour profiter de chacun de leurs avantages. Le tableau ci-dessous compare quelques cas d'usage de ces deux *packages* :
 
 | Je souhaite...                                                            | arrow | duckdb |
 | ------------------------------------------------------------------------- | ----- | ------ |
@@ -82,6 +82,8 @@ Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir 
 | Travailler sur un fichier .parquet ou .csv sans le charger entièrement en mémoire | ✔️     | ✔️     |
 | Utiliser la syntaxe `dplyr` pour traiter mes données                      | ✔️     | ✔️     |
 | Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
+| Joindre des tables très volumineuses (plus de 4 Go)                          | ❌     | ✔️     |
+| Utiliser des fonctions fenêtres (voir @sec-arrow)                          | ❌     | ✔️     |
 | Utiliser des fonctions statistiques qui n'existent pas dans arrow (voir @sec-arrow) | ❌     | ✔️     |
 | Écrire un fichier .parquet                                                | ✔️     | ✔️ *   |
 

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -72,7 +72,7 @@ Du point de vue d'un statisticien utilisant `R`, le *package* `duckdb` permet de
 -   __*Traduction en SQL*__: `duckdb` traduit automatiquement les instructions `dplyr` en requêtes SQL (de la même façon qu'`arrow` traduit ces instructions en code C++). Il arrive toutefois que certaines fonctions de `dplyr` n'aient pas d'équivalent direct en `duckdb` et ne puissent être traduites automatiquement. Dans ce cas (qui est heureusement moins fréquent qu'avec `arrow`), il faut parfois utiliser une fonction SQL directement ou trouver une solution pour contourner le problème. La @sec-sql donne quelques trucs et astuces dans ce cas.
 -   __Interopérabilité__: `duckdb` est conçu pour être interopérable entre plusieurs langages de programmation tels que `R`, Python, Java, C++, etc. Cela signifie que les données peuvent être échangées entre ces langages sans avoir besoin de convertir les données, d'où des gains importants de temps et de performance.
 
-## Quand utiliser `duckdb` plutôt que `arrow` ?
+### Quand utiliser `duckdb` plutôt que `arrow` ?
 
 Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir la fiche [Manipuler des données avec `arrow`](#arrow)), mais on peut préférer l'un à l'autre selon les cas. On peut également les utiliser ensemble pour profiter de chacun de leurs avantages. Le tableau ci-dessous compare quelques cas d'usage de ces deux **packages** :
 

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -79,8 +79,7 @@ Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir 
 | Je souhaite...                                                            | arrow | duckdb |
 | ------------------------------------------------------------------------- | ----- | ------ |
 | Optimiser mes traitements pour des données volumineuses                   | ✔️     | ✔️     |
-| Travailler sur un fichier .parquet sans le charger entièrement en mémoire | ✔️     | ✔️     |
-| Travailler sur un fichier .csv️ sans le charger entièrement en mémoire     | ❌     | ✔️     |
+| Travailler sur un fichier .parquet ou .csv sans le charger entièrement en mémoire | ✔️     | ✔️     |
 | Utiliser la syntaxe `dplyr` pour traiter mes données                      | ✔️     | ✔️     |
 | Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
 | Utiliser des fonctions statistiques qui n'existent pas dans arrow (voir @sec-arrow) | ❌     | ✔️     |

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -72,6 +72,22 @@ Du point de vue d'un statisticien utilisant `R`, le *package* `duckdb` permet de
 -   __*Traduction en SQL*__: `duckdb` traduit automatiquement les instructions `dplyr` en requêtes SQL (de la même façon qu'`arrow` traduit ces instructions en code C++). Il arrive toutefois que certaines fonctions de `dplyr` n'aient pas d'équivalent direct en `duckdb` et ne puissent être traduites automatiquement. Dans ce cas (qui est heureusement moins fréquent qu'avec `arrow`), il faut parfois utiliser une fonction SQL directement ou trouver une solution pour contourner le problème. La @sec-sql donne quelques trucs et astuces dans ce cas.
 -   __Interopérabilité__: `duckdb` est conçu pour être interopérable entre plusieurs langages de programmation tels que `R`, Python, Java, C++, etc. Cela signifie que les données peuvent être échangées entre ces langages sans avoir besoin de convertir les données, d'où des gains importants de temps et de performance.
 
+## Quand utiliser `duckdb` plutôt que `arrow` ?
+
+Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir la fiche [Manipuler des données avec `arrow`](#arrow)), mais on peut préférer l'un à l'autre selon les cas. On peut également les utiliser ensemble pour profiter de chacun de leurs avantages. Le tableau ci-dessous compare quelques cas d'usage de ces deux **packages** :
+
+| Je souhaite...                                                            | arrow | duckdb |
+| ------------------------------------------------------------------------- | ----- | ------ |
+| Optimiser mes traitements pour des données volumineuses                   | ✔️     | ✔️     |
+| Travailler sur un fichier .parquet sans le charger entièrement en mémoire | ✔️     | ✔️     |
+| Travailler sur un fichier .csv️ sans le charger entièrement en mémoire     | ❌     | ✔️     |
+| Utiliser la syntaxe `dplyr` pour traiter mes données                      | ✔️     | ✔️     |
+| Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
+| Utiliser des fonctions statistiques qui n'existent pas dans arrow         | ❌     | ✔️     |
+| Écrire un fichier .parquet                                                | ✔️     | ❌     |
+| Modifier des valeurs dans ma table sans la réécrire en entier             | ❌     | ✔️     |
+
+
 ## Installation de `duckdb`
 
 Il suffit d'installer le _package_ `duckdb`, qui contient à la fois `DuckDB` et une interface pour que `R` puisse s'y connecter.

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -85,7 +85,6 @@ Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir 
 | Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
 | Utiliser des fonctions statistiques qui n'existent pas dans arrow         | ❌     | ✔️     |
 | Écrire un fichier .parquet                                                | ✔️     | ❌     |
-| Modifier des valeurs dans ma table sans la réécrire en entier             | ❌     | ✔️     |
 
 
 ## Installation de `duckdb`

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -83,9 +83,10 @@ Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir 
 | Travailler sur un fichier .csv️ sans le charger entièrement en mémoire     | ❌     | ✔️     |
 | Utiliser la syntaxe `dplyr` pour traiter mes données                      | ✔️     | ✔️     |
 | Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
-| Écrire un fichier .parquet                                                | ✔️     | ❌     |
 | Utiliser des fonctions statistiques qui n'existent pas dans arrow (voir @sec-arrow) | ❌     | ✔️     |
+| Écrire un fichier .parquet                                                | ✔️     | ✔️ *   |
 
+\* pour écrire un fichier .parquet avec le package `duckdb`, il faut utiliser une instruction SQL (voir @sec-ecrire-parquet)
 
 ## Installation de `duckdb`
 
@@ -595,7 +596,7 @@ resultats <- dbGetQuery(conn_ddb, "SELECT * FROM data1_nettoye LEFT JOIN data2_n
 
 Et vous pouvez bien sûr créer des tables intermédiaires (temporaires ou non) à la place des vues (en utilisant `CREATE TABLE` pluôt que `CREATE VIEW`) pour éviter de les recalculer à chaque fois.
 
-#### Écrire des fichiers
+#### Écrire des fichiers {#sec-ecrire-parquet}
 
 Vous pouvez exporter des données vers des fichiers en utilisant [`COPY ... TO ...`](https://duckdb.org/docs/sql/statements/copy.html#copy--to) :
 

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -83,8 +83,8 @@ Les **packages** `duckdb` et `arrow` ont des cas d'usage très similaires (voir 
 | Travailler sur un fichier .csv️ sans le charger entièrement en mémoire     | ❌     | ✔️     |
 | Utiliser la syntaxe `dplyr` pour traiter mes données                      | ✔️     | ✔️     |
 | Utiliser du langage SQL pour traiter mes données                          | ❌     | ✔️     |
-| Utiliser des fonctions statistiques qui n'existent pas dans arrow         | ❌     | ✔️     |
 | Écrire un fichier .parquet                                                | ✔️     | ❌     |
+| Utiliser des fonctions statistiques qui n'existent pas dans arrow (voir @sec-arrow) | ❌     | ✔️     |
 
 
 ## Installation de `duckdb`
@@ -744,7 +744,7 @@ f <- function(x) {
 purrr::walk(f, groups)
 ```
 
-## Comparaison avec `arrow`
+## Comparaison avec `arrow` {#sec-arrow}
 
 `arrow` et `duckdb` partagent de nombreux concepts. Voici quelques différences : 
 


### PR DESCRIPTION
Dans la foulée de la publication de cette superbe fiche duckdb, je propose d'ajouter un petit tableau synthétique comparant certains cas d'usage de duckdb et arrow. En l'état actuel des choses, il me semble en effet difficile pour un utilisateur débutant de savoir pourquoi utiliser l'un, l'autre ou les deux packages.

C'est une ébauche : le contenu du tableau est ouvert à discussion, pour ajouter ou retirer des items.
J'ai choisi de le mettre dans la partie introductive après "Quels sont les avantages de duckdb?" et "Quels sont les points d’attention à l’usage ?", mais je suis là aussi ouvert à la discussion.