### PR TITLE
correction d'un lien non fonctionnel

### DIFF
--- a/03_Fiches_thematiques/Fiche_configurer_git.qmd
+++ b/03_Fiches_thematiques/Fiche_configurer_git.qmd
@@ -80,7 +80,7 @@ la forge sont censés connaître : un mot de passe, une clé compliquée, un jet
 
 Plus précisément, il existe deux modalités pour faire connaître son identité à `GitLab` :
 
-* une **authentification HTTPS** ([décrite ici](git-connexion-https)) : l'authentification se fait avec un _login_ et un mot de passe (qu'il faut renseigner à chaque interaction avec le dépôt), ou avec un _token_ (méthode à privilégier).
+* une **authentification HTTPS** ([décrite ici](#git-connexion-https)) : l'authentification se fait avec un _login_ et un mot de passe (qu'il faut renseigner à chaque interaction avec le dépôt), ou avec un _token_ (méthode à privilégier).
 * **une authentification SSH** : l'authentification se fait par une clé cryptée disponible sur le poste de travail et que `GitHub` ou `GitLab` connaît. Une fois configurée, cette méthode ne nécessite plus de faire connaître son identité : l'empreinte digitale que constitue la clé suffit à reconnaître un utilisateur. 
 
 ::: {.callout-tip}
@@ -119,7 +119,7 @@ et taper la commande suivante :
 git config --global http.sslVerify false
 ~~~
 
-Il est également possible d'utiliser l'[authentification SSH](#git-connexion-ssh)
+Il est également possible d'utiliser [l'authentification SSH](#git-connexion-ssh)
 
 :::
 


### PR DESCRIPTION
Il manquait un # dans un lien interne à la page pour qu'il soit fonctionnel. J'ai aussi rentré le "l'" dans le texte d'un autre lien uniquement pour des questions cosmétiques.