### PR TITLE
rajouter exemple pour measure()

### DIFF
--- a/03_Fiches_thematiques/Fiche_datatable.qmd
+++ b/03_Fiches_thematiques/Fiche_datatable.qmd
@@ -422,13 +422,13 @@ donnees_pauvrete_long
 Parfois il est plus simple de préciser les `measure.vars` avec une expression régulière, qu'on pourrait utiliser en précisant `measure.vars=measure(nom_de_colonne1, nom_de_colonne2, pattern="expression")`, comme dans le code ci-dessous :
 
 ```{r
-donnees_pauvrete_long_measure <- melt(
-  filosofi_epci_2016_dt,
-  id.vars="CODGEO",
-  value.name="taux_pauvrete",
-  measure.vars=measure(
-    tranche_age, age, tranche, pattern="(TP60(|AGE)(|[1-6])16)")
-)
+donnees_pauvrete_long_measure <-
+  melt(filosofi_epci_2016_dt,
+       id.vars = "CODGEO",
+       value.name = "taux_pauvrete",
+       measure.vars = measure(tranche_age, age, tranche,
+                              pattern="(TP60(|AGE)(|[1-6])16)")
+  )
 donnees_pauvrete_long_measure
 ```
 


### PR DESCRIPTION

## Checklist:

En faisant cette *pull request*, je confirme que :

- [x ] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [x ] Ma proposition respecte les canons formels de la documentation `utilitR`
- [ x] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`

Bonjour
Je mène un projet pour améliorer les documentation sur data.table, et j'ai trouvé votre page aujourd'hui, qui est très bien !

Ce PR 

* rajoute un exemple avancé pour `melt()` avec la nouvelle fonction `measure()`
* rajoute un lien vers la vignette correspondante (en français)

J'ai essayé quarto render sur ma machine, mais ça rame ? (ne réponde pas)

Par contre le code que j'ai rajouté marche bien :

```r
> donnees_pauvrete_long_measure <- melt(
+ filosofi_epci_2016_dt,
+ id.vars="CODGEO",
+ value.name="taux_pauvrete",
+ measure.vars=measure(
+ tranche_age, age, tranche, pattern="(TP60(|AGE)(|[1-6])16)")
+ )
> donnees_pauvrete_long_measure
         CODGEO tranche_age    age tranche taux_pauvrete
         <char>      <char> <char>  <char>         <num>
   1: 200000172      TP6016                          8.8
   2: 200000438      TP6016                          8.0
   3: 200000545      TP6016                         23.7
   4: 200000628      TP6016                         20.1
   5: 200000800      TP6016                         11.4
  ---                                                   
8704: 249740077  TP60AGE616    AGE       6          44.3
8705: 249740085  TP60AGE616    AGE       6          41.5
8706: 249740093  TP60AGE616    AGE       6          43.4
8707: 249740101  TP60AGE616    AGE       6          39.8
8708: 249740119  TP60AGE616    AGE       6          31.7
> sessionInfo()
R version 4.5.1 (2025-06-13 ucrt)
Platform: x86_64-w64-mingw32/x64
Running under: Windows 11 x64 (build 26100)

Matrix products: default
  LAPACK version 3.12.1

locale:
[1] LC_COLLATE=English_United States.utf8 
[2] LC_CTYPE=English_United States.utf8   
[3] LC_MONETARY=English_United States.utf8
[4] LC_NUMERIC=C                          
[5] LC_TIME=English_United States.utf8    

time zone: America/Toronto
tzcode source: internal

attached base packages:
[1] stats     graphics  utils     datasets  grDevices methods   base     

other attached packages:
[1] data.table_1.17.99 animint2_2025.8.16

loaded via a namespace (and not attached):
 [1] gtable_0.3.6               jsonlite_2.0.0            
 [3] compiler_4.5.1             promises_1.3.3            
 [5] Rcpp_1.1.0                 doremifasolData_0.2.0.9000
 [7] stringr_1.5.1              callr_3.7.6               
 [9] later_1.4.4                scales_1.4.0              
[11] yaml_2.3.10                fastmap_1.2.0             
[13] mime_0.13                  R6_2.6.1                  
[15] plyr_1.8.9                 labeling_0.4.3            
[17] curl_7.0.0                 knitr_1.50                
[19] desc_1.4.3                 RColorBrewer_1.1-3        
[21] rlang_1.1.6                stringi_1.8.7             
[23] httpuv_1.6.16              xfun_0.53                 
[25] RJSONIO_2.0.0              cli_3.6.5                 
[27] magrittr_2.0.3             ps_1.9.1                  
[29] digest_0.6.37              grid_4.5.1                
[31] processx_3.8.6             rstudioapi_0.17.1         
[33] remotes_2.5.0              lifecycle_1.0.4           
[35] servr_0.32                 evaluate_1.0.5            
[37] glue_1.8.0                 farver_2.1.2              
[39] pkgbuild_1.4.8             rmarkdown_2.29            
[41] reshape2_1.4.4             htmltools_0.5.8.1         
[43] tools_4.5.1                quarto_1.5.0              
```
