### PR TITLE
Add GitHub Actions workflow for Quarto preview

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,55 @@
+on:
+  pull_request:
+    branches: main
+
+name: Quarto Preview
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.6'
+
+      - name: Install dependencies
+        run: |
+          sudo ./docker/dependencies.sh
+          curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
+          export PATH="~/.local/bin:$PATH"
+          source ~/.bashrc
+          rv sync
+
+      - name: Set up Quarto environment
+        uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Render Quarto
+        run: quarto render
+
+      - name: Deploy preview to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          destination_dir: previews/pr-${{ github.event.pull_request.number }}
+          keep_files: true
+
+      - name: Comment PR with preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr_number = context.issue.number;
+            const preview_url = `https://${{ github.repository_owner }}.github.io/utilitR/previews/pr-${pr_number}/`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🔍 Preview deployed! View it here: [PR #${pr_number} Preview](${preview_url})`
+            });


### PR DESCRIPTION
Workflow pour lancer une preview complète du site sur une URL dédiée à chaque PR sur main.

Disclaimer : j'ai demandé à Github Copilot de me rédiger ce yaml...

<!-----------

**Compléter une description indicative ici.**

Si la modification est associée à une *issue*, elle peut être identifiée par son numéro, par exemple `#10`.

Pour fermer automatiquement une *issue* lorsque la `pull request` sera validée, marquer

```markdown
`close #XX`
```

en remplaçant  `#XX` par le numéro de l'*issue* (par exemple `#10`)

## Checklist:

En faisant cette *pull request*, je confirme que :

- [X] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`

-------------->
