### PR TITLE
Remove bioconductor repository from rproject.toml

### DIFF
--- a/rproject.toml
+++ b/rproject.toml
@@ -6,9 +6,8 @@ r_version = "4.6"
 # The alias is only used in this file if you want to specifically require a dependency to come from a certain repository.
 # Example: { alias = "PPM", url = "https://packagemanager.posit.co/cran/latest" },
 repositories = [
-    {alias = "PPM", url = "https://packagemanager.posit.co/cran/latest"},
+    { alias = "PPM", url = "https://packagemanager.posit.co/cran/latest" },
     { alias = "CRAN", url = "https://cran.r-project.org" },
-    { alias = "bioconductor", url = "https://bioconductor.org/packages/release/bioc", force_source = true }
 ]
 
 # A list of packages to install and any additional configuration


### PR DESCRIPTION
See #571

Unreliable URL results in:
504 Gateway Timeout ERROR
The request could not be satisfied.

En faisant cette *pull request*, je confirme que :

- [ ] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [ ] Ma proposition respecte les canons formels de la documentation `utilitR`
- [ ] Les exemples de code `R` ont été testés sur ma machine
- [ ] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [ ] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`