### PR TITLE
Passer de doremifasoldata à S3 #562

### DIFF
--- a/01_R_Insee/Fiche_installer_packages.qmd
+++ b/01_R_Insee/Fiche_installer_packages.qmd
@@ -112,8 +112,8 @@ Certains _packages_ sont mis à disposition sur une [forge logicielle](https://f
 Le _package_ `remotes` a pour finalité principale d'installer des _packages_ depuis des forges logicielles. Pour installer un _package_ depuis une forge, il faut utiliser la fonction dédiée : `install_github` pour GitHub, `install_gitlab` pour GitLab, `install_svn` pour SVN, etc... Voici un exemple :
 
 ```{r, eval = FALSE}
-# installe depuis `https://github.com/InseeFrLab/doremifasolData`
-remotes::install_github(repo = "InseeFrLab/doremifasolData")
+# installe depuis `https://github.com/InseeFrLab/doremifasol`
+remotes::install_github(repo = "InseeFrLab/doremifasol")
 ```
 
 Seul le premier argument (`repo`) est obligatoire. Il est formé du nom du
@@ -122,7 +122,7 @@ contiendra les modifications les plus récentes. Installer depuis une forge
 permet ainsi de récupérer la version de développement d'un _package_
 (seules les versions stables sont en général disponibles sur le CRAN). Pour installer
 un _package_ tel qu'il était à un moment donné, il est également possible de
-faire suivre le nom du dépôt par une référence à un `commit`, à un _tag_ (une version) ou à une ` branche`. Voici un exemple avec un _tag_ : `remotes::install_gitlab("py_b/funprog@v-0.3.0")`. Voici un exemple avec un commit : `remotes::install_github("InseeFrLab/doremifasolData@a9df2d3d0e372")`.
+faire suivre le nom du dépôt par une référence à un `commit`, à un _tag_ (une version) ou à une ` branche`. Voici un exemple avec un _tag_ : `remotes::install_gitlab("py_b/funprog@v-0.3.0")`. Voici un exemple avec un commit : `remotes::install_github("InseeFrLab/doremifasol@a03bf37c54bdf2f9bc4f99754aac453a44a0b86c")`.
 
 ::: {.callout-note}
 Lorsque vous installez un _package_ depuis une forge logicielle, `R` crée automatiquement une archive temporaire (un fichier `.tar.gz`), puis installe le _package_ à partir de celle-ci. Si vous travaillez dans un environnement Windows, il est nécessaire que `Rtools` soit installé sur votre poste pour que `R` puisse construire l'archive. 

--- a/01_R_Insee/Fiche_utiliser_utilitR.qmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.qmd
@@ -111,40 +111,13 @@ Comme les bonnes pratiques sont de stocker le code sur Git et les données sur u
 
 Voici la liste des tables disponibles dans `doremifasolData` et stockées sur le S3 du SSPCloud :
 
-<table class="caption-top table">
-<thead><tr class="header">
-<th data-quarto-table-cell-role="th" style="text-align: center; font-weight: bold;">Table</th>
-<th data-quarto-table-cell-role="th" style="text-align: left; font-weight: bold;">Description</th>
-<th data-quarto-table-cell-role="th" style="text-align: left; font-weight: bold;">Chemin S3</th>
-</tr></thead>
-<tbody>
-<tr class="odd">
-<td style="text-align: center; width: 4cm;">bpe_ens_2018</td>
-<td style="text-align: left; width: 13cm;">Base Permanente des Équipements 2018</td>
-<td style="text-align: left; width: 13cm;"> <a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet</a></td>
-</tr>
-<tr class="even">
-<td style="text-align: center; width: 4cm;">cog_com_2019</td>
-<td style="text-align: left; width: 13cm;">Code Officiel Géographique 2019</td>
-<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet</a></td>
-</tr>
-<tr class="odd">
-<td style="text-align: center; width: 4cm;">data_iris_paris_2017</td>
-<td style="text-align: left; width: 13cm;">Données sociales sur les IRIS de Paris 2017</td>
-<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet</a></td>
-</tr>
-<tr class="even">
-<td style="text-align: center; width: 4cm;">filosofi_com_2016</td>
-<td style="text-align: left; width: 13cm;">Données sur les revenus et la pauvreté en 2016, niveau communal</td>
-<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet</a></td>
-</tr>
-<tr class="odd">
-<td style="text-align: center; width: 4cm;">filosofi_epci_2016</td>
-<td style="text-align: left; width: 13cm;">Données sur les revenus et la pauvreté en 2016, niveau EPCI</td>
-<td style="text-align: left; width: 13cm;"> <a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet</a></td>
-</tr>
-</tbody>
-</table>
+| Table | Description | Chemin S3 |
+| --- | --- | --- |
+| bpe_ens_2018 | Base Permanente des Équipements 2018 | [s3/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet](https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet) |
+| cog_com_2019 | Code Officiel Géographique 2019 | [s3/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet](https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet) |
+| data_iris_paris_2017 | Données sociales sur les IRIS de Paris 2017 | [s3/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet](https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet) |
+| filosofi_com_2016 | Données sur les revenus et la pauvreté en 2016, niveau communal | [s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet](https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet) |
+| filosofi_epci_2016 | Données sur les revenus et la pauvreté en 2016, niveau EPCI | [s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet](https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet) |
 
 ::: {.callout-note}
 

--- a/01_R_Insee/Fiche_utiliser_utilitR.qmd
+++ b/01_R_Insee/Fiche_utiliser_utilitR.qmd
@@ -107,30 +107,65 @@ Voici un exemple : la fiche sur la manipulation de données textuelles commence 
 
 Ces jeux de données sont mis à disposition par l'intermédiaire d'un _package_ nommé `doremifasolData` développé par les contributeurs du projet `utilitR`. La documentation détaillée de ce _package_ est disponible [sur GitHub](https://inseefrlab.github.io/DoReMIFaSolData/).
 
-Voici la liste des tables disponibles dans `doremifasolData` :
+Comme les bonnes pratiques sont de stocker le code sur Git et les données sur un serveur de stockage (S3 pour le SSPCloud et LS3), les tables de sortie du package `doremifasolData` ont aussi été stockées sur un serveur S3 du SSPCloud à l'adresse https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/ au format `.parquet`. 
 
-```{r "contenu_doremifasolData", echo = FALSE, results = "asis"}
-tables <- data(package = "doremifasolData")$results
+Voici la liste des tables disponibles dans `doremifasolData` et stockées sur le S3 du SSPCloud :
 
-output <- 
-  knitr::kable(
-  as.data.frame(list("Table" = tables[, "Item"], "Description" = tables[, "Title"])),
-  format = "html",
-  escape = F, position = "center", full_width = F, align="cl") %>%
-  kableExtra::column_spec(1, width = "4cm") %>%
-  kableExtra::column_spec(2, width = "13cm") %>% 
-  kableExtra::row_spec(0, bold=TRUE, align = "c")
-output
-```
+<table class="caption-top table">
+<thead><tr class="header">
+<th data-quarto-table-cell-role="th" style="text-align: center; font-weight: bold;">Table</th>
+<th data-quarto-table-cell-role="th" style="text-align: left; font-weight: bold;">Description</th>
+<th data-quarto-table-cell-role="th" style="text-align: left; font-weight: bold;">Chemin S3</th>
+</tr></thead>
+<tbody>
+<tr class="odd">
+<td style="text-align: center; width: 4cm;">bpe_ens_2018</td>
+<td style="text-align: left; width: 13cm;">Base Permanente des Équipements 2018</td>
+<td style="text-align: left; width: 13cm;"> <a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: center; width: 4cm;">cog_com_2019</td>
+<td style="text-align: left; width: 13cm;">Code Officiel Géographique 2019</td>
+<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: center; width: 4cm;">data_iris_paris_2017</td>
+<td style="text-align: left; width: 13cm;">Données sociales sur les IRIS de Paris 2017</td>
+<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet</a></td>
+</tr>
+<tr class="even">
+<td style="text-align: center; width: 4cm;">filosofi_com_2016</td>
+<td style="text-align: left; width: 13cm;">Données sur les revenus et la pauvreté en 2016, niveau communal</td>
+<td style="text-align: left; width: 13cm;"><a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet</a></td>
+</tr>
+<tr class="odd">
+<td style="text-align: center; width: 4cm;">filosofi_epci_2016</td>
+<td style="text-align: left; width: 13cm;">Données sur les revenus et la pauvreté en 2016, niveau EPCI</td>
+<td style="text-align: left; width: 13cm;"> <a href="https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet" target="_blank">s3/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet</a></td>
+</tr>
+</tbody>
+</table>
 
 ::: {.callout-note}
 
 Le package tire son nom de son "grand frère", le _package_ [`doremifasol`](https://inseefrlab.github.io/DoReMIFaSol). Ce _package_ a pour finalité de charger dans `R` des données disponibles sur le site de l'Insee, sans que l'utilisateur n'ait ni à naviguer sur ce site, ni à effectuer l'import des données. Tous les jeux de données présents dans `doremifasolData` ont été téléchargés avec `doremifasol`.
 :::
 
+
 ### Comment installer le _package_ `doremifasolData`
 
-Le _package_ `doremifasolData` n'est pas disponible sur le répertoire central des _packages_ `R` (le CRAN). Pour installer installer le _package_, il est nécessaire d'exécuter les deux commandes suivantes :
+Vous n'avez pas besoin d'installer le _package_ `doremifasolData`. Le code va directement télécharger les données depuis le S3 du SSPCloud avec une requête SQL de la forme :
+
+```{r, eval = FALSE}
+duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
+")  |>
+  dplyr::slice_head(n = 5)
+```
+
+Cependant, si vous voulez utiliser le _package_ `doremifasolData`, il n'est pas disponible sur le répertoire central des _packages_ `R` (le CRAN). Pour installer installer le _package_, il est nécessaire d'exécuter les deux commandes suivantes :
 
 ```{r, eval = FALSE}
 install.packages("remotes")
@@ -140,7 +175,7 @@ remotes::install_github("InseeFrLab/doremifasolData", ref = "main")
 ::: {.callout-warning}
 ## Spécificité Insee
 
-Si vous utilisez `R` sur un poste Insee (y compris en télétravail) ou dans l'environnement de travail AUS, il faut exécuter la commande suivante :
+Si vous utilisez `R` sur un poste Insee (y compris en télétravail) ou dans l'environnement de travail AUS, les données du SSPCloud ne sont pas accessibles. Il faut alors utiliser directement le package `doremifasolData` pour accéder aux données. Pour installer le _package_ `doremifasolData`, il est nécessaire d'exécuter la commande suivante :
 
 ```{r, eval = FALSE}
 install.packages(

--- a/02_Bonnes_pratiques/01-qualite-code.qmd
+++ b/02_Bonnes_pratiques/01-qualite-code.qmd
@@ -268,7 +268,7 @@ library(MASS)
 bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ")
 
 nombre <- bpe_ens_2018 %>%

--- a/02_Bonnes_pratiques/01-qualite-code.qmd
+++ b/02_Bonnes_pratiques/01-qualite-code.qmd
@@ -265,7 +265,11 @@ car il est nécessaire d'exécuter le code pour les détecter. Par exemple, le c
 #| error: true
 library(dplyr)
 library(MASS)
-bpe_ens_2018 <- doremifasolData::bpe_ens_2018
+bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+")
 
 nombre <- bpe_ens_2018 %>%
   as_tibble() %>%

--- a/03_Fiches_thematiques/Fiche_arrow.qmd
+++ b/03_Fiches_thematiques/Fiche_arrow.qmd
@@ -113,14 +113,14 @@ Par rapport à un `data.frame` standard ou à un `tibble`, le `Arrow Table` se d
 bpe_ens_2018_tbl   <- bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ") |> as_tibble()
 
 # Charger les données et les convertir en Arrow Table
 bpe_ens_2018_arrow <- bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ") |> as_arrow_table()
 ```
 

--- a/03_Fiches_thematiques/Fiche_arrow.qmd
+++ b/03_Fiches_thematiques/Fiche_arrow.qmd
@@ -110,10 +110,18 @@ Par rapport à un `data.frame` standard ou à un `tibble`, le `Arrow Table` se d
 
 ```{r}
 # Charger les données et les convertir en tibble
-bpe_ens_2018_tbl   <- doremifasolData::bpe_ens_2018 |> as_tibble()
+bpe_ens_2018_tbl   <- bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+") |> as_tibble()
 
 # Charger les données et les convertir en Arrow Table
-bpe_ens_2018_arrow <- doremifasolData::bpe_ens_2018 |> as_arrow_table()
+bpe_ens_2018_arrow <- bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+") |> as_arrow_table()
 ```
 
 Première différence: alors que les `data.frames` et les `tibbles` apparaissent dans la rubrique `Data` de l'environnement `RStudio` (cadre rouge dans la capture d'écran), les objets `Arrow Table` apparaissent dans la rubrique `Values` (cadre blanc).

--- a/03_Fiches_thematiques/Fiche_datatable.qmd
+++ b/03_Fiches_thematiques/Fiche_datatable.qmd
@@ -246,7 +246,7 @@ Dans la suite de cette section, on va illustrer les opérations de base en `data
 bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ")
 # Convertir ce data.frame en data.table
 bpe_ens_2018_dt <- data.table::as.data.table(bpe_ens_2018)
@@ -410,7 +410,7 @@ Pour illustrer l'usage de cette fonction, nous allons utiliser les données du r
 filosofi_epci_2016 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_epci_2016.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet'
 ")
 # Convertir la table en data.table
 filosofi_epci_2016_dt <- data.table::as.data.table(filosofi_epci_2016)
@@ -678,7 +678,7 @@ filosofi_com_2016_dt <- data.table::as.data.table(
   duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet'
   ")
 )
 # Créer une variable donnant le département

--- a/03_Fiches_thematiques/Fiche_datatable.qmd
+++ b/03_Fiches_thematiques/Fiche_datatable.qmd
@@ -233,11 +233,7 @@ Partir de `dt`, créer une nouvelle variable `newvar` qui vaut 1 pour les observ
 
 ## Manipuler des tables de données avec `data.table`
 
-Nous allons illustrer les fonctions de manipulation de données de `data.table` avec les jeux de données du _package_ `doremifasolData`.
-
-```{r, echo = TRUE}
-library(doremifasolData)
-```
+Nous allons illustrer les fonctions de manipulation de données de `data.table`.
 
 ### Mettre des données dans un `data.table`
 
@@ -250,9 +246,13 @@ Dans la suite de cette section, on va illustrer les opérations de base en `data
 
 ```{r}
 # Charger la base permanente des équipements
-bpe_ens_2018 <- doremifasolData::bpe_ens_2018
+bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+")
 # Convertir ce data.frame en data.table
-bpe_ens_2018_dt <- as.data.table(bpe_ens_2018)
+bpe_ens_2018_dt <- data.table::as.data.table(bpe_ens_2018)
 ```
 
 ### Manipuler une seule table avec `data.table`

--- a/03_Fiches_thematiques/Fiche_datatable.qmd
+++ b/03_Fiches_thematiques/Fiche_datatable.qmd
@@ -410,9 +410,13 @@ Pour illustrer l'usage de cette fonction, nous allons utiliser les données du r
 
 ```{r}
 # Charger la table de Filosofi
-filosofi_epci_2016 <- doremifasolData::filosofi_epci_2016
+filosofi_epci_2016 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_epci_2016.parquet'
+")
 # Convertir la table en data.table
-filosofi_epci_2016_dt <- as.data.table(filosofi_epci_2016)
+filosofi_epci_2016_dt <- data.table::as.data.table(filosofi_epci_2016)
 # Sélectionner des colonnes
 filosofi_epci_2016_dt <- 
   filosofi_epci_2016_dt[, .(CODGEO, TP6016, TP60AGE116, TP60AGE216, 
@@ -669,11 +673,17 @@ L'utilisation de la fonction `:=` est déroutante lorsqu'on découvre `data.tabl
 
 ## Programmer des fonctions avec `data.table`
 
-Une des forces de `data.table` est qu'il est relativement simple d'utiliser ce _package_ dans des fonctions. Pour illustrer l'usage des fonctions, nous allons utiliser la table `filosofi_com_2016` disponible dans le _package_ `doremifasolData`. Cette table donne des informations sur les revenus des ménages au niveau communal. Nous créons une variable donnant le numéro du département (`departement`) en extrayant les deux premiers caractères du code commune (`CODGEO`) avec la fonction `str_sub` du _package_ `stringr` (vous pouvez consulter la fiche [Manipuler des données textuelles pour en apprendre davantage sur `stringr`]). Enfin, nous utilisons la fonction `.SD` pour sélectionner uniquement quelques variables.
+Une des forces de `data.table` est qu'il est relativement simple d'utiliser ce _package_ dans des fonctions. Pour illustrer l'usage des fonctions, nous allons utiliser la table `filosofi_com_2016` disponible sur le [stockage de données (dit S3) du sspcloud](https://datalab.sspcloud.fr/s3/?profile=default). Cette table donne des informations sur les revenus des ménages au niveau communal. Nous créons une variable donnant le numéro du département (`departement`) en extrayant les deux premiers caractères du code commune (`CODGEO`) avec la fonction `str_sub` du _package_ `stringr` (vous pouvez consulter la fiche [Manipuler des données textuelles pour en apprendre davantage sur `stringr`]). Enfin, nous utilisons la fonction `.SD` pour sélectionner uniquement quelques variables.
 
 ```{r}
 # Charger la table de données et la transformer en data.table
-filosofi_com_2016_dt <- as.data.table(doremifasolData::filosofi_com_2016)
+filosofi_com_2016_dt <- data.table::as.data.table(
+  duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+  ")
+)
 # Créer une variable donnant le département
 filosofi_com_2016_dt[, departement := stringr::str_sub(CODGEO, start = 1L, end = 2L)]
 # Supprimer les départements d'outre-mer

--- a/03_Fiches_thematiques/Fiche_datatable.qmd
+++ b/03_Fiches_thematiques/Fiche_datatable.qmd
@@ -11,9 +11,6 @@ L'utilisateur souhaite manipuler des données structurées sous forme de `data.f
 * Pour des tables de données de grande taille (plus de 1 Go ou plus d'un million d'observations), il est recommandé d'utiliser soit le _package_ `data.table` qui fait l'objet de la présente fiche, soit les _packages_ `arrow` et `duckdb` présentés dans les fiches [Manipuler des données avec `arrow`](#arrow) et [Manipuler des données avec `duckdb`](#duckdb).
 :::
 
-::: {.callout-note}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
-:::
 
 ## Présentation de `data.table`
 
@@ -406,7 +403,7 @@ La fonction `melt()` réorganise les donnée dans un format long. Elle prend les
 * `variable.name` : le nom de la nouvelle colonne qui contient le nom des variables transposées ;
 * `value.name` : le nom de la nouvelle colonne qui contient la valeur des variables transposées.
 
-Pour illustrer l'usage de cette fonction, nous allons utiliser les données du répertoire Filosofi 2016 agrégées au niveau des EPCI (table `filosofi_epci_2016`), et disponibles dans le package `doremifasolData`. On convertit cette table en `data.table` et on conserve uniquement certaines variables.
+Pour illustrer l'usage de cette fonction, nous allons utiliser les données du répertoire Filosofi 2016 agrégées au niveau des EPCI (table `filosofi_epci_2016`), et disponibles sur S3. On convertit cette table en `data.table` et on conserve uniquement certaines variables.
 
 ```{r}
 # Charger la table de Filosofi
@@ -505,7 +502,7 @@ bpe_ens_2018_wide2
 
 **Il est conseillé de bien réfléchir avant de restructurer des données en format *wide*, et de ne le faire que lorsque cela paraît indispensable**. En effet, s'il est tentant de restructurer les données sous format *wide* car ce format peut paraître plus intuitif, il est généralement plus simple et plus rigoureux de traiter les données en format *long*. Ceci dit, il existe des situations dans lesquelles il est indiqué de restructurer les données en format *wide*. Voici deux exemples :
 
-* produire un tableau synthétique de résultats, prêt à être diffusé, avec quelques colonnes donnant des indicateurs par catégorie (exemple : la table `filosofi_epci_2016` du _package_ `doremifasolData`) ;
+* produire un tableau synthétique de résultats, prêt à être diffusé, avec quelques colonnes donnant des indicateurs par catégorie (exemple : la table `filosofi_epci_2016`) ;
 * produire une table avec une colonne par année, de façon à calculer facilement un taux d'évolution entre deux dates.
 :::
   

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -156,7 +156,11 @@ __La fonction `duckdb_register()` permet de charger dans `duckdb` des données p
 
 ```{r}
 # Charger la Base permanente des équipements 2018 dans la session R
-bpe_ens_2018 <- doremifasolData::bpe_ens_2018 |> as_tibble()
+bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+") |> as_tibble()
 
 # Etablir le lien logique entre la base de données duckdb et la table de données
 conn_ddb %>% duckdb::duckdb_register(
@@ -228,7 +232,11 @@ Dans l'exemple suivant, on calcule le nombre d'équipements par région, à part
 __Manipulation d'un `tibble`__
 
 ```{r message=FALSE}
-doremifasolData::bpe_ens_2018 |>
+duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+") |>
   group_by(REG) |>
   summarise(
     NB_EQUIP_TOT = sum(NB_EQUIP)

--- a/03_Fiches_thematiques/Fiche_duckdb.qmd
+++ b/03_Fiches_thematiques/Fiche_duckdb.qmd
@@ -159,7 +159,7 @@ __La fonction `duckdb_register()` permet de charger dans `duckdb` des données p
 bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ") |> as_tibble()
 
 # Etablir le lien logique entre la base de données duckdb et la table de données
@@ -235,7 +235,7 @@ __Manipulation d'un `tibble`__
 duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ") |>
   group_by(REG) |>
   summarise(

--- a/03_Fiches_thematiques/Fiche_graphiques.qmd
+++ b/03_Fiches_thematiques/Fiche_graphiques.qmd
@@ -10,10 +10,6 @@ L'utilisateur souhaite réaliser des graphiques (nuages de points, histogrammes,
 * Il est conseillé aux utilisateurs débutants d'utiliser l'*add-in* `esquisse` pour se familiariser avec `ggplot2`.
 :::
 
-::: {.callout-note}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
-:::
-
 
 ## Découvrir `ggplot2` avec l'_add-in_ `esquisse`
 
@@ -39,11 +35,14 @@ L'_add-in_ `esquisse` est disponible sous la forme d'un _package_, qu'il faut in
 install.packages("esquisse")
 ```
 
-Cette section illustre l'utilisation d'`esquisse` avec la table `data_iris_paris_2017` du _package_ `doremifasolData`, qui contient des données économiques et sociales sur les iris de la ville de Paris en 2017. Il faut donc charger ces données dans `R` :
+Cette section illustre l'utilisation d'`esquisse` avec la table `data_iris_paris_2017`, qui contient des données économiques et sociales sur les iris de la ville de Paris en 2017. Il faut donc charger ces données dans `R` :
 
 ```{r, message = FALSE}
-library(doremifasolData)
-data_iris_paris2017 <- doremifasolData::data_iris_paris_2017
+data_iris_paris2017 <- duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/data_iris_paris_2017.parquet'
+  ")
 ```
 
 Une fois qu'il est installé, vous pouvez accéder à cet _add-in_ en cliquant sur *'ggplot2' builder* dans le menu _Addins_ de  RStudio.
@@ -83,12 +82,15 @@ Une fois que le graphique est terminé, vous pouvez récupérer le code `ggplot2
 
 L'objectif du *package* `ggplot2` est de fournir une approche unique pour produire quasiment toute représentation graphique de données. Ce _package_ propose un grand nombre de fonctions permettant de personnaliser finement les représentations graphiques. Cette fiche n'est donc qu'une introduction succincte à `ggplot2`. Pour des formations plus détaillées, se référer à {#ggplot2Ressources}.
 
-Pour commencer, il faut charger le _package_ avec `library`. Cette fiche illustre l'utilisation de `ggplot2` avec la table `data_iris_paris_2017` du _package_ `doremifasolData`, qui contient des données économiques et sociales sur les iris de la ville de Paris en 2017.
+Pour commencer, il faut charger le _package_ avec `library`. Cette fiche illustre l'utilisation de `ggplot2` avec la table `data_iris_paris_2017` stockée sur le S3, qui contient des données économiques et sociales sur les iris de la ville de Paris en 2017.
 
 ```{r, message = FALSE}
 library(ggplot2)
-library(doremifasolData)
-data_iris_paris_2017 <- doremifasolData::data_iris_paris_2017
+data_iris_paris_2017 <- duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/data_iris_paris_2017.parquet'
+  ")
 ggplot2::theme_set(theme_minimal())
 ```
 

--- a/03_Fiches_thematiques/Fiche_graphiques.qmd
+++ b/03_Fiches_thematiques/Fiche_graphiques.qmd
@@ -41,7 +41,7 @@ Cette section illustre l'utilisation d'`esquisse` avec la table `data_iris_paris
 data_iris_paris2017 <- duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/data_iris_paris_2017.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet'
   ")
 ```
 
@@ -89,7 +89,7 @@ library(ggplot2)
 data_iris_paris_2017 <- duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/data_iris_paris_2017.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet'
   ")
 ggplot2::theme_set(theme_minimal())
 ```

--- a/03_Fiches_thematiques/Fiche_joindre_donnees.qmd
+++ b/03_Fiches_thematiques/Fiche_joindre_donnees.qmd
@@ -12,9 +12,7 @@ Vous souhaitez apparier deux tables de données selon une ou plusieurs variables
 * Il est vivement recommandé de lire la section [Quelques bonnes pratiques sur les jointures] avant de réaliser des jointures.
 :::
 
-::: {.callout-note}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
-:::
+
 
 ## Les différents types de jointure
 
@@ -63,11 +61,21 @@ Cette section présente les principales fonctions permettant de réaliser des jo
 Il est possible de réaliser les jointures avec chacune des trois approches présentées ici. Il est néanmoins conseillé d'être cohérent avec les outils de manipulation de données que vous utilisez. Si vous manipulez vos données avec `data.table`, il sera préférable d'utiliser la fonction `merge` de ce _package_ qui est optimisée pour les objets `data.table`. Si vous manipulez vos données avec le `tidyverse`, il est recommandé d'utiliser les fonctions du *package* `dplyr`.
 :::
 
-Les fonctions de jointure vont être illustrées avec la table des communes du code officiel géographique 2019 et les données du répertoire Filosofi 2016 agrégées par commune. Ces tables sont disponibles dans le _package_ `doremifasolData`. Pour alléger les sorties, on conserve uniquement l'identifiant de commune, le revenu médian 2016 `MED16` et le taux de pauvreté `TP6016` dans la première table, et l'identifiant de commune `com`, le type de commune `typecom`, le nom officiel de la commune `libelle` et son département `dep` dans la seconde table.
+Les fonctions de jointure vont être illustrées avec la table des communes du code officiel géographique 2019 et les données du répertoire Filosofi 2016 agrégées par commune. Ces tables sont chargées sur le S3 du SSPCloud. Pour alléger les sorties, on conserve uniquement l'identifiant de commune, le revenu médian 2016 `MED16` et le taux de pauvreté `TP6016` dans la première table, et l'identifiant de commune `com`, le type de commune `typecom`, le nom officiel de la commune `libelle` et son département `dep` dans la seconde table.
 
 ```{r import_donnees}
-library(doremifasolData)
+filosofi_com_2016 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+")
 filosofi_com_2016 <- filosofi_com_2016[, c("CODGEO", "MED16", "TP6016")]
+
+cog_com_2019 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+")
 cog_com_2019 <- cog_com_2019[, c("com", "typecom", "libelle", "dep")]
 ```
 

--- a/03_Fiches_thematiques/Fiche_joindre_donnees.qmd
+++ b/03_Fiches_thematiques/Fiche_joindre_donnees.qmd
@@ -67,14 +67,14 @@ Les fonctions de jointure vont être illustrées avec la table des communes du c
 filosofi_com_2016 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet'
 ")
 filosofi_com_2016 <- filosofi_com_2016[, c("CODGEO", "MED16", "TP6016")]
 
 cog_com_2019 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
 ")
 cog_com_2019 <- cog_com_2019[, c("com", "typecom", "libelle", "dep")]
 ```

--- a/03_Fiches_thematiques/Fiche_rmarkdown.qmd
+++ b/03_Fiches_thematiques/Fiche_rmarkdown.qmd
@@ -17,10 +17,6 @@ L'utilisateur souhaite produire avec `R` des documents contenant à la fois du t
 * Pour aller plus loin et s'exercer sur `R Markdown`, il est recommandé de lire le chapitre sur `R Markdown` dans la formation [Travail collaboratif avec `R`](https://linogaliana.gitlab.io/collaboratif/rmd.html).
 :::
 
-::: {.callout-note}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
-:::
-
 ## Présentation générale de `R Markdown`
 
 `R Markdown` est une extension de `R` qui se présente sous la forme d'un _package_. `R Markdown` permet de produire des documents texte en y intégrant nativement des morceaux de code `R` (pour le rendre public, pour générer des sorties...). `R Markdown` permet de fluidifier le processus de rédaction d'une publication, en réduisant fortement le nombre de gestes manuels nécessaires pour inclure des graphiques ou du code dans un document : plutôt qu'avoir un code `SAS` ou `Stata` ayant généré des sorties `Excel`/`Calc` intégrées dans un document `Word` ou transformées en table `LaTeX`, on dispose d'un unique document-source qui contient à la fois le texte et les codes qui produisent les sorties du document final. L'utilisation de `R Markdown` facilite la production de publications reproductibles.
@@ -534,13 +530,16 @@ Des éléments supplémentaires de stylisation sont disponibles dans le [guide d
 
 ### Une table basique en `R Markdown`
 
-Supposons, par exemple, qu'on désire faire la liste de toutes les communes dont le libellé contient "Montreuil-sur". On commence par récupérer les données du Code officiel géographique 2019, disponibles dans le _package_ `doremifasolData`. On utilise ensuite le _package_ `stringr` pour repérer les communes dont le libellé contient "Montreuil-sur" (l'usage de ce package est détaillé dans la fiche [Manipuler des données textuelles]).
+Supposons, par exemple, qu'on désire faire la liste de toutes les communes dont le libellé contient "Montreuil-sur". On commence par récupérer les données du Code officiel géographique 2019, disponibles sur le S3 du SSPCloud (et provenant du package `DoremifasolData`). On utilise ensuite le package `stringr` pour repérer les communes dont le libellé contient "Montreuil-sur" (l'usage de ce package est détaillé dans la fiche [Manipuler des données textuelles]).
 
 ```{r}
-library(doremifasolData)
 library(stringr)
 # Charger les données du COG
-cog_com_2019 <- doremifasolData::cog_com_2019
+cog_com_2019 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+")
 montreuil <- 
   cog_com_2019[stringr::str_detect(cog_com_2019$libelle, "Montreuil-sur"), c("libelle","com")]
 ```
@@ -595,16 +594,19 @@ utilitr::render_rmd("resources/rmarkdown/chunk08.Rmd")
 
 ### Sans passer par un fichier image
 
-`R Markdown` présente l'avantage de pouvoir créer un document sans générer de sorties intermédiaires (tableaux, graphiques...). Si un bloc de code propose d'inséer un graphique dans le document final, le graphique sera automatiquement et directement intégré au document. Par exemple, le bloc suivant permet de représenter l'histogramme des populations communales (avec une échelle logarithmique) à partir des données Filosofi agrégées, disponibles dans le _package_ `doremifasolData`.
+`R Markdown` présente l'avantage de pouvoir créer un document sans générer de sorties intermédiaires (tableaux, graphiques...). Si un bloc de code propose d'inséer un graphique dans le document final, le graphique sera automatiquement et directement intégré au document. Par exemple, le bloc suivant permet de représenter l'histogramme des populations communales (avec une échelle logarithmique) à partir des données Filosofi agrégées, disponibles sur le S3 du SSPCloud.
 
 ```{r chunk09, echo = FALSE, comment = "", eval = FALSE}
 utilitr::render_rmd("resources/rmarkdown/chunk09.Rmd")
 ```
 
 ```{r ggplot2, warning = FALSE, comment = FALSE, message = FALSE, eval = FALSE}
-library(doremifasolData)
 library(ggplot2)
-filosofi_com_2016 <- doremifasolData::filosofi_com_2016
+filosofi_com_2016 <- duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+  ")
 ggplot(data = filosofi_com_2016) +
   geom_histogram(aes(x = NBPERSMENFISC16, y = ..density..)) +
   xlab("Nombre de personnes") + ylab("Densité") +

--- a/03_Fiches_thematiques/Fiche_rmarkdown.qmd
+++ b/03_Fiches_thematiques/Fiche_rmarkdown.qmd
@@ -538,7 +538,7 @@ library(stringr)
 cog_com_2019 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
 ")
 montreuil <- 
   cog_com_2019[stringr::str_detect(cog_com_2019$libelle, "Montreuil-sur"), c("libelle","com")]
@@ -605,7 +605,7 @@ library(ggplot2)
 filosofi_com_2016 <- duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet'
   ")
 ggplot(data = filosofi_com_2016) +
   geom_histogram(aes(x = NBPERSMENFISC16, y = ..density..)) +

--- a/03_Fiches_thematiques/Fiche_rmarkdown_param_report.qmd
+++ b/03_Fiches_thematiques/Fiche_rmarkdown_param_report.qmd
@@ -103,7 +103,6 @@ A titre d'exemple, les deux *chunks* qui chargent les _packages_ et les données
 
 ````markdown
 `r ''````{r packages, include = FALSE}
-library(doremifasolData)
 library(data.table)
 library(ggplot2)
 ```

--- a/03_Fiches_thematiques/Fiche_tidyverse.qmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.qmd
@@ -66,7 +66,11 @@ Les objets récupérés en sortie de `doremifasolData` sont tous des `data.frame
 
 ```{r}
 # Charger la base permanente des équipements
-bpe_ens_2018 <- doremifasolData::bpe_ens_2018
+bpe_ens_2018 <- duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+")
 # Convertir ce data.frame en tibble
 bpe_ens_2018_tbl <- as_tibble(bpe_ens_2018)
 ```

--- a/03_Fiches_thematiques/Fiche_tidyverse.qmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.qmd
@@ -12,9 +12,6 @@ L'utilisateur souhaite manipuler des données structurées sous forme de `data.f
 * Pour des tables de données de grande taille (plus de 1 Go ou plus d'un million d'observations), il est recommandé d'utiliser soit le _package_ `data.table` présenté dans la fiche [Manipuler des données avec `data.table`](#datatable), soit les _packages_ `arrow` et `duckdb` présentés dans les fiches [Manipuler des données avec `arrow`](#arrow) et [Manipuler des données avec `duckdb`](#duckdb).
 :::
 
-::: {.callout-note}
-Certains exemples de cette fiche utilisent les données disponibles dans le _package_ `doremifasolData` ; vous ne pourrez reproduire ces exemples que si ce _package_ est installé sur la machine sur laquelle vous travaillez. Si vous ne savez pas si ce _package_ est déjà installé, consultez la fiche [Comment utiliser la documentation `utilitR`](#presentation-utilitr).
-:::
 
 ## Présentation des _packages_ `dplyr`, `tidyr` et `tibble`
 
@@ -51,13 +48,10 @@ options(dplyr.print_min  = 6)
 options(dplyr.print_max  = 6)
 ```
 
-Les exemples de cette fiche s’appuient sur les données disponibles dans le *package* `doremifasolData`. On utilise en premier lieu la base permanente des équipements 2018.
+Les exemples de cette fiche s’appuient sur les données disponibles sur S3 et provenant du *package* `doremifasolData`. On utilise en premier lieu la base permanente des équipements 2018.
 
-```{r}
-library(doremifasolData)
-```
 
-Les objets récupérés en sortie de `doremifasolData` sont tous des `data.frame`, bien que le _package_ s'appuie sur des fonctions issues de `tidyverse`. Il est donc nécessaire de les convertir en `tibble` avec la fonction `as_tibble` du *package* `tibble`.
+Les objets récupérés en sortie de S3 et provenant  `doremifasolData` sont tous des `data.frame`, bien que le _package_ s'appuie sur des fonctions issues de `tidyverse`. Il est donc nécessaire de les convertir en `tibble` avec la fonction `as_tibble` du *package* `tibble`.
 
 ### Le `tibble` : un `data.frame` amélioré
 
@@ -434,8 +428,19 @@ Il est préférable d'utiliser ces fonctions sur des objets `tibble` plutôt que
 
 ```{r, message = FALSE, warning = FALSE}
 library(dplyr)
-filosofi_com_2016_tbl <- as_tibble(doremifasolData::filosofi_com_2016)
-cog_com_2019_tbl <- as_tibble(doremifasolData::cog_com_2019)
+filosofi_com_2016_tbl <- as_tibble(filosofi_com_2016_dt <- data.table::as.data.table(
+  duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+  ")
+  )
+cog_com_2019_tbl <- as_tibble(filosofi_com_2016_dt <- data.table::as.data.table(
+  duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+  "))
 ```
 
 Voici un exemple dans lequel on utilise la fonction `left_join` pour réaliser une jointure à gauche entre la table des données Filosofi et la table des communes du COG.
@@ -509,7 +514,11 @@ La fonction `separate_wider_position` attend ensuite l'argument `widths` sous la
 Voici un exemple qui utilise la table des communes du Code Officiel Géographique. Dans cette table, la colonne `com` (code commune Insee) contient deux informations : le numéro du département et le numéro de la commune.
 
 ```{r}
-cog_com_2019_tbl <- doremifasolData::cog_com_2019 %>% as_tibble()
+cog_com_2019_tbl <- duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+  ") %>% as_tibble()
 cog_com_2019_tbl
 ```
 
@@ -612,9 +621,16 @@ Une table de données stocke des informations sous forme de lignes et de colonne
 ![Transformation *long to wide*](../pics/datatable/longtowide.png)
 
 
-Pour illustrer ces transformations, nous allons utiliser les données du répertoire Filosofi 2016 agrégées au niveau des EPCI (table `filosofi_epci_2016`), et disponibles dans le _package_ `doremifasolData`. On convertit cette table en `tibble` et on conserve uniquement certaines variables grâce à la fonction `select`.
+Pour illustrer ces transformations, nous allons utiliser les données du répertoire Filosofi 2016 agrégées au niveau des EPCI (table `filosofi_epci_2016`), et disponibles sur le S3 du SSPCloud. On convertit cette table en `tibble` et on conserve uniquement certaines variables grâce à la fonction `select`.
 
 ```{r}
+
+filosofi_epci_2016 <- duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_epci_2016.parquet'
+  ")
+
 filosofi_epci_2016_tbl <- as_tibble(filosofi_epci_2016) %>% 
   select(CODGEO, TP6016, TP60AGE116, TP60AGE216,
          TP60AGE316, TP60AGE416, TP60AGE516, TP60AGE616)

--- a/03_Fiches_thematiques/Fiche_tidyverse.qmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.qmd
@@ -64,7 +64,7 @@ Les objets récupérés en sortie de S3 et provenant  `doremifasolData` sont tou
 bpe_ens_2018 <- duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/bpe_ens_2018.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/bpe_ens_2018.parquet'
 ")
 # Convertir ce data.frame en tibble
 bpe_ens_2018_tbl <- as_tibble(bpe_ens_2018)
@@ -432,14 +432,14 @@ filosofi_com_2016_tbl <- as_tibble(filosofi_com_2016_dt <- data.table::as.data.t
   duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet'
   ")
   )
 cog_com_2019_tbl <- as_tibble(filosofi_com_2016_dt <- data.table::as.data.table(
   duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
   "))
 ```
 
@@ -517,7 +517,7 @@ Voici un exemple qui utilise la table des communes du Code Officiel Géographiqu
 cog_com_2019_tbl <- duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
   ") %>% as_tibble()
 cog_com_2019_tbl
 ```
@@ -628,7 +628,7 @@ Pour illustrer ces transformations, nous allons utiliser les données du répert
 filosofi_epci_2016 <- duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_epci_2016.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_epci_2016.parquet'
   ")
 
 filosofi_epci_2016_tbl <- as_tibble(filosofi_epci_2016) %>% 

--- a/03_Fiches_thematiques/Fiche_tidyverse.qmd
+++ b/03_Fiches_thematiques/Fiche_tidyverse.qmd
@@ -56,6 +56,7 @@ Les exemples de cette fiche s’appuient sur les données disponibles dans le *p
 ```{r}
 library(doremifasolData)
 ```
+
 Les objets récupérés en sortie de `doremifasolData` sont tous des `data.frame`, bien que le _package_ s'appuie sur des fonctions issues de `tidyverse`. Il est donc nécessaire de les convertir en `tibble` avec la fonction `as_tibble` du *package* `tibble`.
 
 ### Le `tibble` : un `data.frame` amélioré

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ disponible. Chaque fiche, disponible sur le site web, peut être imprimée
 avec une mise en page agréable grâce à un bouton dédié sur le site web.
 
 Les exemples sont construits sur des données ouvertes, disponibles sur www.insee.fr. 
-Le package [`doremifasolData`](https://github.com/InseeFrLab/DoReMIFaSolData) facilite
-l'import de ces données dans la documentation. Le modèle de document est
+Le modèle de document est
 encapsulé dans un *package* `R` dédié: https://github.com/InseeFrLab/utilitr-template 
 
 L'ensemble des ressources du projet `utilitR` sont disponibles sur https://www.utilitr.org

--- a/resources/rapportsparam/rapportParametre.Rmd
+++ b/resources/rapportsparam/rapportParametre.Rmd
@@ -24,7 +24,7 @@ library(data.table)
 cog_com_2019 <- data.table::as.data.table(duckdb::sql_query("
   INSTALL httpfs;
   LOAD httpfs;
-  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/cog_com_2019.parquet'
 "))
 ```
 

--- a/resources/rapportsparam/rapportParametre.Rmd
+++ b/resources/rapportsparam/rapportParametre.Rmd
@@ -17,12 +17,15 @@ knitr::opts_chunk$set(echo = FALSE,
 ```
 
 ```{r load-packages}
-library(doremifasolData)
 library(data.table)
 ```
 
 ```{r importData}
-cog_com_2019 <- as.data.table(doremifasolData::cog_com_2019)
+cog_com_2019 <- data.table::as.data.table(duckdb::sql_query("
+  INSTALL httpfs;
+  LOAD httpfs;
+  SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/cog_com_2019.parquet'
+"))
 ```
 
 ```{r selectData}

--- a/resources/targets/_targets_mod2.R
+++ b/resources/targets/_targets_mod2.R
@@ -13,7 +13,7 @@ readr::write_csv(filosofi_com_2016_dt <- data.table::as.data.table(
   duckdb::sql_query("
     INSTALL httpfs;
     LOAD httpfs;
-    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/filosofi_com_2016.parquet'
   "), raw_file_path)
 
 list(

--- a/resources/targets/_targets_mod2.R
+++ b/resources/targets/_targets_mod2.R
@@ -9,7 +9,12 @@ source("mesfonctions_pour_faire_ceci.R", encoding = "utf-8")
 # on crée un fichier à partir d'un des jeux d'exemples
 raw_file_path <- "data/donnes_entrees.csv"
 dir.create("data")
-readr::write_csv(doremifasolData::filosofi_com_2016, raw_file_path)
+readr::write_csv(filosofi_com_2016_dt <- data.table::as.data.table(
+  duckdb::sql_query("
+    INSTALL httpfs;
+    LOAD httpfs;
+    SELECT * FROM 'https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/filosofi_com_2016.parquet'
+  "), raw_file_path)
 
 list(
   

--- a/rproject.toml
+++ b/rproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "arrow",
     "kableExtra",
     { name = "doremifasol", git = "https://github.com/InseeFrLab/DoReMIFaSol", branch = "master" },
-    { name = "doremifasolData", git = "https://github.com/InseeFrLab/DoReMIFaSolData", branch = "main" },
     "targets",
     "openxlsx",
     "readODS",

--- a/rv.lock
+++ b/rv.lock
@@ -577,13 +577,6 @@ dependencies = [
 ]
 
 [[packages]]
-name = "doremifasolData"
-version = "0.2.0.9000"
-source = { git = "https://github.com/InseeFrLab/DoReMIFaSolData", sha = "d67c97adbd0210f572e0ef5e1466967b514e4dc8", branch = "main" }
-force_source = true
-dependencies = []
-
-[[packages]]
 name = "downlit"
 version = "0.4.5"
 source = { repository = "https://packagemanager.posit.co/cran/latest" }


### PR DESCRIPTION
Suppression de l'usage de doremifasoldata à S3. 

- Les données du package ont été transférées sur le S3 du sspcloud au format parquet (dans https://minio.lab.sspcloud.fr/projet-formation/diffusion/utilitR/doremifasoldata/data_iris_paris_2017.parquet). 
- Les fiches de utilitR faisant appel à doremifasoldata ont été mises à jour : l'import se fait en exécutant une requête SQL par duckdb avec l'adresse https du fichier. 
- la documentation a été mise à jour (il n'est plus recommandé d'utiliser le package)
- le package est retiré des dépendances de rv

close #562 

## Checklist:

En faisant cette *pull request*, je confirme que :

- [x] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [X] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [X] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`
