### PR TITLE
Add preview script

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -53,18 +53,14 @@ jobs:
           destination_dir: previews/pr-${{ github.event.pull_request.number }}
           keep_files: true
 
-      - name: Comment PR with preview link
-        uses: actions/github-script@v7
+      - name: Comment PR (custom)
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
-          script: |
-            const pr_number = context.issue.number;
-            const preview_url = `https://${{ github.repository_owner }}.github.io/utilitR/previews/pr-${pr_number}/`;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🔍 Preview deployed! View it here: [PR #${pr_number} Preview](${preview_url})`
-            });
+          header: pr-preview
+          message: |
+            :rocket: View preview at <br> ${{ steps.deploy-preview.outputs.preview-url }} <br>
+            <h6>Built to branch <a href="${{ github.server_url }}/${{ github.repository }}/tree/gh-pages"> gh-pages </a> at ${{ steps.deploy-preview.outputs.action-start-time }}. <br> Preview will be ready when the <a href="${{ github.server_url }}/${{ github.repository }}/deployments">GitHub Pages deployment</a> is complete. <br> </h6>
+  
 
 # For this workflow only
   delete-preview:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
+          publish_dir: ./_public
           destination_dir: previews/pr-${{ github.event.pull_request.number }}
           keep_files: true
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,8 +26,8 @@ jobs:
         run: |
           sudo ./docker/dependencies.sh
           curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
-          export PATH="~/.local/bin:$PATH"
-          source ~/.bashrc
+          export PATH="$HOME/.local/bin:$PATH"  # Use $HOME instead of ~ for reliability
+          . ~/.bashrc  
           rv sync
 
       - name: Don't publish CNAME for preview

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -8,7 +8,7 @@ jobs:
   build-preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
     container:
       image: inseefrlab/onyxia-r-minimal:r4.6.0
@@ -16,11 +16,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-
-      # - name: Install R
-      #   uses: r-lib/actions/setup-r@v2
-      #   with:
-      #     r-version: '4.6'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -27,6 +27,10 @@ jobs:
           source ~/.bashrc
           rv sync
 
+      - name: Don't publish CNAME for preview
+        run: |
+          rm CNAME
+
       - name: Set up Quarto environment
         uses: quarto-dev/quarto-actions/setup@v2
 

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -82,6 +82,7 @@ jobs:
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           action: remove
+          umbrella-dir: previews  # <-- Match your deploy directory
           token: ${{ secrets.GITHUB_TOKEN }}  
 
       - name: Comment PR that preview was removed

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -68,6 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for gh-pages pushes
+      pull-requests: write  # Required to comment PR
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -5,7 +5,8 @@ on:
 name: Quarto Preview
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}  # Unique Quarto Preview per PR
+  cancel-in-progress: true
 
 jobs:
   build-preview:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   build-preview:
+    if: github.event.action != 'closed' # If closing the PR, no publishing
     runs-on: ubuntu-latest
     permissions:
       contents: write  # For pushing to gh-pages branch
@@ -59,3 +60,30 @@ jobs:
               repo: context.repo.repo,
               body: `🔍 Preview deployed! View it here: [PR #${pr_number} Preview](${preview_url})`
             });
+
+# For this workflow only
+  delete-preview:
+    if: github.event.action == 'closed' # Only run when PR is closed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # To enable full access to Git repo
+          ref: ${{ github.event.pull_request.head.ref }} # Reference of the commit to checkout to. To ensure it's the one of the PR
+          repository: ${{github.event.pull_request.head.repo.full_name}} # Reference to the branch to checkout to. Useful with PR from forks
+
+      - name: Remove preview
+        id: remove-preview
+        uses: rossjrw/pr-preview-action@v1.8.1
+        with:
+          action: remove
+          token: ${{ secrets.DEPLOY_GH_PAGES_TOKEN }}  # Uses a token to allow preview from forks
+
+      - name: Comment PR that preview was removed
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: pr-preview
+          message: |
+            Preview removed because the pull request was closed.
+            ${{ steps.remove-preview.outputs.action-start-time }}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,7 +12,8 @@ jobs:
   build-preview:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write  # For pushing to gh-pages branch
+      pull-requests: write  # For permissions to write comments on PRs
     container:
       image: inseefrlab/onyxia-r-minimal:r4.6.0
       options: --user root  # Force root user

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: write
     container:
-      image: inseefrlab/onyxia-r-minimal:4.6.0
+      image: inseefrlab/onyxia-r-minimal:r4.6.0
       volumes:
       - /tmp/data:/data
     steps:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -12,8 +12,7 @@ jobs:
       pull-requests: write
     container:
       image: inseefrlab/onyxia-r-minimal:r4.6.0
-      volumes:
-      - /tmp/data:/data
+      options: --user root  # Force root user
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo ./docker/dependencies.sh
+          # sudo ./docker/dependencies.sh
           curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
           export PATH="$HOME/.local/bin:$PATH"  # Use $HOME instead of ~ for reliability
           . ~/.bashrc  

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          # sudo ./docker/dependencies.sh
           curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
           export PATH="$HOME/.local/bin:$PATH"  # Use $HOME instead of ~ for reliability
           . ~/.bashrc  # no source command for this container, so use . instead
@@ -82,7 +81,7 @@ jobs:
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           action: remove
-          umbrella-dir: previews  # <-- Match your deploy directory
+          umbrella-dir: previews  
           token: ${{ secrets.GITHUB_TOKEN }}  
 
       - name: Comment PR that preview was removed

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize # When the ref of the branch is updated (= commit to the branch to merge)
+    - closed # Including closed to remove preview when PR is closed.
     branches: main
 
 name: Quarto Preview

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -10,14 +10,18 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    container:
+      image: inseefrlab/onyxia-r-minimal:4.6.0
+      volumes:
+      - /tmp/data:/data
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Install R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: '4.6'
+      # - name: Install R
+      #   uses: r-lib/actions/setup-r@v2
+      #   with:
+      #     r-version: '4.6'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -64,23 +64,24 @@ jobs:
 
 # For this workflow only
   delete-preview:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' # Only run when PR is closed
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for gh-pages pushes
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # To enable full access to Git repo
+          ref: ${{ github.event.pull_request.head.ref }} # Reference of the commit to checkout to. To ensure it's the one of the PR
+          repository: ${{github.event.pull_request.head.repo.full_name}} # Reference to the branch to checkout to. Useful with PR from forks
+
       - name: Remove preview
+        id: remove-preview
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           action: remove
-          token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-repository: ${{ github.repository }}
-          preview-branch: gh-pages
-          umbrella-dir: previews  # Match your deploy dir (e.g., "previews/pr-1")
-        env:
-          DEPLOY_REPO: ${{ github.repository }}
-          DEPLOY_BRANCH: gh-pages
-          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}  
 
       - name: Comment PR that preview was removed
         uses: marocchino/sticky-pull-request-comment@v3

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,12 +4,14 @@ on:
 
 name: Quarto Preview
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
 jobs:
   build-preview:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     container:
       image: inseefrlab/onyxia-r-minimal:r4.6.0
       options: --user root  # Force root user

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -32,7 +32,7 @@ jobs:
           # sudo ./docker/dependencies.sh
           curl -sSL https://raw.githubusercontent.com/A2-ai/rv/refs/heads/main/scripts/install.sh | bash
           export PATH="$HOME/.local/bin:$PATH"  # Use $HOME instead of ~ for reliability
-          . ~/.bashrc  
+          . ~/.bashrc  # no source command for this container, so use . instead
           rv sync
 
       - name: Don't publish CNAME for preview
@@ -64,22 +64,23 @@ jobs:
 
 # For this workflow only
   delete-preview:
-    if: github.event.action == 'closed' # Only run when PR is closed
+    if: github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required for gh-pages pushes
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0 # To enable full access to Git repo
-          ref: ${{ github.event.pull_request.head.ref }} # Reference of the commit to checkout to. To ensure it's the one of the PR
-          repository: ${{github.event.pull_request.head.repo.full_name}} # Reference to the branch to checkout to. Useful with PR from forks
-
       - name: Remove preview
-        id: remove-preview
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           action: remove
-          token: ${{ secrets.DEPLOY_GH_PAGES_TOKEN }}  # Uses a token to allow preview from forks
+          token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-repository: ${{ github.repository }}
+          preview-branch: gh-pages
+          umbrella-dir: previews  # Match your deploy dir (e.g., "previews/pr-1")
+        env:
+          DEPLOY_REPO: ${{ github.repository }}
+          DEPLOY_BRANCH: gh-pages
+          DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Comment PR that preview was removed
         uses: marocchino/sticky-pull-request-comment@v3


### PR DESCRIPTION
Close #588 

Update du GHA workflow de preview : 
- passage à un container Onyxia pour gagner du temps sur la préview (plus R à installer)
- on n'installe plus dependancies.sh (fonctionne tb sans => inutile ? )
- mise à jour quand le workflow démarre : PR faite sur main, ouverte, nouveau push, ou fermée. 
- ajout remove preview quand la PR est fermée

## Checklist:

En faisant cette *pull request*, je confirme que :

- [X] J'ai lu le [guide des contributeurs](CONTRIBUTING.md)
- [X] Ma proposition respecte les canons formels de la documentation `utilitR`
- [X] Les exemples de code `R` ont été testés sur ma machine
- [X] J'ai testé, sur ma machine, que la documentation compile avec mes ajouts (`quarto::quarto_preview()`) produit un résultat
- [X] Si j'y suis invité (cela ne fonctionne pas pour toutes les `pull requests`), je consulte le site de prévisualisation `https://${BRANCH_NAME}--preview-docr.netlify.app/`